### PR TITLE
[R1065] initial implementation of skos:altLabel and skos:prefLabel on term detail

### DIFF
--- a/src/component/misc/StringListEdit.scss
+++ b/src/component/misc/StringListEdit.scss
@@ -1,0 +1,3 @@
+.no-shadow-box {
+  box-shadow: none !important;
+}

--- a/src/component/misc/StringListEdit.tsx
+++ b/src/component/misc/StringListEdit.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import {injectIntl} from "react-intl";
+import withI18n, {HasI18n} from "../hoc/withI18n";
+import {Badge, Button, FormText, Input, InputGroup, InputGroupAddon, Label} from "reactstrap";
+import {GoPlus} from "react-icons/go";
+import {FaTrashAlt} from "react-icons/fa";
+import "./StringListEdit.scss";
+import Utils from "../../util/Utils";
+
+interface StringListEditProps extends HasI18n {
+    list: string[];
+    onChange: (list: string[]) => void;
+    i18nPrefix: string;
+}
+
+interface StringListEditState {
+    inputValue: string;
+}
+
+export class StringListEdit extends React.Component<StringListEditProps, StringListEditState> {
+    constructor(props: StringListEditProps) {
+        super(props);
+        this.state = {
+            inputValue: ""
+        };
+    }
+
+    private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({inputValue: e.currentTarget.value});
+    };
+
+    private onKeyPress = (e: React.KeyboardEvent) => {
+        if (e.key === "Enter") {
+            this.onAdd();
+        }
+    };
+
+    private onAdd = () => {
+        if (this.state.inputValue.length === 0) {
+            return;
+        }
+        const newList = Utils.sanitizeArray(this.props.list).slice();
+        newList.push(this.state.inputValue);
+        this.props.onChange(newList);
+        this.setState({inputValue: ""});
+    };
+
+    private onRemove = (item: string) => {
+        const newList = Utils.sanitizeArray(this.props.list).slice();
+        newList.splice(newList.indexOf(item), 1);
+        this.props.onChange(newList);
+    };
+
+    private getText = (keySuffix : string) => {
+        return this.props.i18n(this.props.i18nPrefix+"."+keySuffix)
+    }
+
+    public render() {
+        return <div>
+            <Label className="attribute-label">{this.getText("label")}</Label>
+            <InputGroup className="form-group no-shadow-box">
+                <Input name="add-string-input" value={this.state.inputValue} onChange={this.onChange}
+                       bsSize="sm" onKeyPress={this.onKeyPress}
+                       placeholder={this.getText("placeholder")}/>
+                <InputGroupAddon addonType="append">
+                    <Button id="add-string-submit" color="primary" size="sm" onClick={this.onAdd}
+                            className="term-edit-source-add-button" disabled={this.state.inputValue.trim().length === 0}
+                            title={this.getText("placeholder.title")}><GoPlus/>&nbsp;{this.getText("placeholder.text")}
+                    </Button>
+                </InputGroupAddon>
+                <FormText>{this.getText("help")}</FormText>
+            </InputGroup>
+            {this.renderList()}
+
+        </div>;
+    }
+
+    private renderList() {
+        const list = Utils.sanitizeArray(this.props.list);
+        if (list.length === 0) {
+            return null;
+        }
+        return <ul className="term-items">
+            {list.map(s => <li key={s}>
+                {s}
+                <Badge title={this.getText("remove.title")}
+                       className="term-edit-source-remove align-middle"
+                       onClick={this.onRemove.bind(null, s)}><FaTrashAlt/> {this.getText("remove.text")}
+                </Badge>
+            </li>)}
+        </ul>;
+    }
+}
+
+export default injectIntl(withI18n(StringListEdit));

--- a/src/component/misc/StringListEdit.tsx
+++ b/src/component/misc/StringListEdit.tsx
@@ -8,7 +8,7 @@ import "./StringListEdit.scss";
 import Utils from "../../util/Utils";
 
 interface StringListEditProps extends HasI18n {
-    list: string[];
+    list?: string[];
     onChange: (list: string[]) => void;
     i18nPrefix: string;
 }

--- a/src/component/misc/__tests__/StringListEdit.test.tsx
+++ b/src/component/misc/__tests__/StringListEdit.test.tsx
@@ -1,41 +1,41 @@
 import * as React from "react";
 import {mountWithIntl} from "../../../__tests__/environment/Environment";
-import {TermSourcesEdit} from "../TermSourcesEdit";
+import {StringListEdit} from "../StringListEdit";
 import {intlFunctions} from "../../../__tests__/environment/IntlUtil";
 import {Badge, Button} from "reactstrap";
 
-describe("TermSourcesEdit", () => {
+describe("StringListEdit", () => {
 
-    let onChange: (sources: string[]) => void;
+    let onChange: (list: string[]) => void;
 
     beforeEach(() => {
         onChange = jest.fn();
     });
 
-    it("adds current input value to sources and invokes onChange on add click", () => {
-        const wrapper = mountWithIntl(<TermSourcesEdit onChange={onChange} sources={[]} {...intlFunctions()}/>);
+    it("adds current input value to list and invokes onChange on add click", () => {
+        const wrapper = mountWithIntl(<StringListEdit onChange={onChange} list={[]} i18nPrefix={""} {...intlFunctions()}/>);
         const input = wrapper.find("input");
-        const value = "new source";
+        const value = "new item";
         (input.getDOMNode() as HTMLInputElement).value = value;
         input.simulate("change", input);
         wrapper.find(Button).simulate("click");
         expect(onChange).toHaveBeenCalledWith([value]);
     });
 
-    it("clears input value after adding new source", () => {
-        const wrapper = mountWithIntl(<TermSourcesEdit onChange={onChange} sources={[]} {...intlFunctions()}/>);
+    it("clears input value after adding new item", () => {
+        const wrapper = mountWithIntl(<StringListEdit onChange={onChange} list={[]} i18nPrefix={""} {...intlFunctions()}/>);
         const input = wrapper.find("input");
-        (input.getDOMNode() as HTMLInputElement).value = "new source";
+        (input.getDOMNode() as HTMLInputElement).value = "new item";
         input.simulate("change", input);
         wrapper.find(Button).simulate("click");
         wrapper.update();
         expect((wrapper.find("input").getDOMNode() as HTMLInputElement).value).toEqual("");
     });
 
-    it("supports adding input value as source on enter", () => {
-        const wrapper = mountWithIntl(<TermSourcesEdit onChange={onChange} sources={[]} {...intlFunctions()}/>);
+    it("supports adding input value as item on enter", () => {
+        const wrapper = mountWithIntl(<StringListEdit onChange={onChange} list={[]} i18nPrefix={""} {...intlFunctions()}/>);
         const input = wrapper.find("input");
-        const value = "new source";
+        const value = "new item";
         (input.getDOMNode() as HTMLInputElement).value = value;
         input.simulate("change", input);
         input.simulate("keyPress", {key: "Enter"});
@@ -43,7 +43,7 @@ describe("TermSourcesEdit", () => {
     });
 
     it("does nothing on add when input is empty", () => {
-        const wrapper = mountWithIntl(<TermSourcesEdit onChange={onChange} sources={[]} {...intlFunctions()}/>);
+        const wrapper = mountWithIntl(<StringListEdit onChange={onChange} list={[]} i18nPrefix={""} {...intlFunctions()}/>);
         const input = wrapper.find("input");
         (input.getDOMNode() as HTMLInputElement).value = "";
         input.simulate("change", input);
@@ -51,15 +51,15 @@ describe("TermSourcesEdit", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
-    it("removes source and calls onChange with updated sources when source remove button is clicked", () => {
-        const sources = ["first", "second"];
-        const wrapper = mountWithIntl(<TermSourcesEdit onChange={onChange} sources={sources} {...intlFunctions()}/>);
+    it("removes item and calls onChange with updated items when item remove button is clicked", () => {
+        const items = ["first", "second"];
+        const wrapper = mountWithIntl(<StringListEdit onChange={onChange} list={items} i18nPrefix={""} {...intlFunctions()}/>);
         wrapper.find(Badge).at(0).simulate("click");
-        expect(onChange).toHaveBeenCalledWith([sources[1]]);
+        expect(onChange).toHaveBeenCalledWith([items[1]]);
     });
 
     it("renders add button disabled when input is empty", () => {
-        const wrapper = mountWithIntl(<TermSourcesEdit onChange={onChange} sources={[]} {...intlFunctions()}/>);
+        const wrapper = mountWithIntl(<StringListEdit onChange={onChange} list={[]} i18nPrefix={""} {...intlFunctions()}/>);
         expect(wrapper.find(Button).prop("disabled")).toBeTruthy();
         const input = wrapper.find("input");
         (input.getDOMNode() as HTMLInputElement).value = "aaa";

--- a/src/component/term/TermDetail.tsx
+++ b/src/component/term/TermDetail.tsx
@@ -93,7 +93,7 @@ export class TermDetail extends EditableComponent<TermDetailProps> {
         const buttons = this.getButtons();
         return <div id="term-detail">
             <HeaderWithActions title={
-                <>{term.label}<CopyIriIcon url={term.iri as string}/></>
+                <>{term.label}<CopyIriIcon url={term.iri as string}/><br/><h6>{Utils.sanitizeArray(term.altLabels || []).join(", ")}</h6></>
             } actions={buttons}/>
 
             {this.state.edit ?

--- a/src/component/term/TermDetail.tsx
+++ b/src/component/term/TermDetail.tsx
@@ -93,7 +93,7 @@ export class TermDetail extends EditableComponent<TermDetailProps> {
         const buttons = this.getButtons();
         return <div id="term-detail">
             <HeaderWithActions title={
-                <>{term.label}<CopyIriIcon url={term.iri as string}/><br/><h6>{Utils.sanitizeArray(term.altLabels || []).join(", ")}</h6></>
+                <>{term.label}<CopyIriIcon url={term.iri as string}/><br/><h6>{Utils.sanitizeArray(term.altLabels).join(", ")}</h6></>
             } actions={buttons}/>
 
             {this.state.edit ?

--- a/src/component/term/TermMetadataEdit.tsx
+++ b/src/component/term/TermMetadataEdit.tsx
@@ -110,14 +110,14 @@ export class TermMetadataEdit extends React.Component<TermMetadataEditProps, Ter
                     </Row>
                     <Row>
                         <Col xs={12}>
-                            <StringListEdit list={this.state.altLabels || []}
+                            <StringListEdit list={this.state.altLabels}
                                             onChange={this.onAltLabelsChange}
                                             i18nPrefix={"term.metadata.altLabels"}/>
                         </Col>
                     </Row>
                     <Row>
                         <Col xs={12}>
-                            <StringListEdit list={this.state.hiddenLabels || []}
+                            <StringListEdit list={this.state.hiddenLabels}
                                             onChange={this.onHiddenLabelsChange}
                                             i18nPrefix={"term.metadata.hiddenLabels"}/>
                         </Col>

--- a/src/component/term/TermMetadataEdit.tsx
+++ b/src/component/term/TermMetadataEdit.tsx
@@ -14,6 +14,7 @@ import Utils from "../../util/Utils";
 import UnmappedPropertiesEdit from "../genericmetadata/UnmappedPropertiesEdit";
 import ParentTermSelector from "./ParentTermSelector";
 import DraftToggle from "./DraftToggle";
+import StringListEdit from "../misc/StringListEdit";
 
 interface TermMetadataEditProps extends HasI18n {
     term: Term,
@@ -54,6 +55,14 @@ export class TermMetadataEdit extends React.Component<TermMetadataEditProps, Ter
     private onSourceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const source = e.currentTarget.value;
         this.setState({sources: [source]});
+    };
+
+    private onHiddenLabelsChange = (hiddenLabels: string[]) => {
+        this.setState({hiddenLabels});
+    };
+
+    private onAltLabelsChange = (altLabels: string[]) => {
+        this.setState({altLabels});
     };
 
     private onTypesChange = (newTypes: string[]) => {
@@ -97,6 +106,20 @@ export class TermMetadataEdit extends React.Component<TermMetadataEditProps, Ter
                                          label={i18n("asset.label")} invalid={this.state.labelExists}
                                          invalidMessage={this.state.labelExists ? this.props.formatMessage("term.metadata.labelExists.message", {label: this.state.label}) : undefined}
                                          help={i18n("term.label.help")}/>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col xs={12}>
+                            <StringListEdit list={this.state.altLabels || []}
+                                            onChange={this.onAltLabelsChange}
+                                            i18nPrefix={"term.metadata.altLabels"}/>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col xs={12}>
+                            <StringListEdit list={this.state.hiddenLabels || []}
+                                            onChange={this.onHiddenLabelsChange}
+                                            i18nPrefix={"term.metadata.hiddenLabels"}/>
                         </Col>
                     </Row>
                     <Row>

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -268,6 +268,22 @@ export default {
         'term.metadata.types': 'Typ pojmu',
         'term.metadata.status': 'Stav pojmu',
         'term.metadata.source': 'Zdroj pojmu',
+        'term.metadata.altLabels.label': 'Synonyma',
+        'term.metadata.altLabels.placeholder': 'Zadejte nové synonymum a stiskněte tlačítko "Přidat"',
+        'term.metadata.altLabels.placeholder.text': 'Přidat',
+        'term.metadata.altLabels.remove': 'Odebrat synonymum',
+        'term.metadata.altLabels.remove.text': 'Odebrat',
+        "term.metadata.altLabels.help": "(Nepovinná) synonyma k názvu. Synonyma mohou být kontextuální - např. pojem " +
+            "s názvem 'Adresa organizace' může mít synonymum 'Adresa', které se však použije jen v určitém kontextu " +
+            "(např. ve formuláři, ve kterém se vyplňují informace o organizaci). ",
+        'term.metadata.hiddenLabels.label': 'Vyhledávací texty',
+        'term.metadata.hiddenLabels.placeholder': 'Zadejte nový vyhledávací text a stiskněte tlačítko "Přidat"',
+        'term.metadata.hiddenLabels.placeholder.text': 'Přidat',
+        'term.metadata.hiddenLabels.remove': 'Odebrat vyhledávací text',
+        'term.metadata.hiddenLabels.remove.text': 'Odebrat',
+        "term.metadata.hiddenLabels.help": "(Nepovinné) vyhledávací texty, nejsou určeny pro vizuální prezentaci pojmu a" +
+            " slouží zejména pro vyhledávání. Nemusí se jednat (ani kontextuální) synonyma k názvu pojmu. Např. " +
+            "pojem s názvem 'Kopaná' může mít vyhledávací text 'fočus'. ",
         'term.updated.message': 'Pojem úspěšně aktualizován.',
         'term.metadata.labelExists.message': "Pojem s názvem \"{label}\" již v tomto slovníku existuje",
         'term.metadata.multipleSources.message': "Pojem má více zdrojů, po uložení pojmu bude pouze aktuálně vyplněný zdroj a ostatní budou smazány",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -262,6 +262,22 @@ export default {
         'term.metadata.subTerms': 'Sub terms',
         'term.metadata.types': 'Type',
         'term.metadata.source': 'Source',
+        'term.metadata.altLabels.label': 'Synonyms',
+        'term.metadata.altLabels.placeholder': 'Enter a new synonym and press "Add"',
+        'term.metadata.altLabels.placeholder.text': 'Add',
+        'term.metadata.altLabels.remove': 'Remove synonym',
+        'term.metadata.altLabels.remove.text': 'Remove',
+        "term.metadata.altLabels.help": "(Optional) synonyms of the label. Synonyms can be contextual - e.g. term " +
+            "named 'Organization address' can have a synonym 'Address', which is used in a specific context only " +
+            "(e.g. in a form gathering information about an organization). ",
+        'term.metadata.hiddenLabels.label': 'Search strings',
+        'term.metadata.hiddenLabels.placeholder': 'Enter a new search string and press "Add"',
+        'term.metadata.hiddenLabels.placeholder.text': 'Add',
+        'term.metadata.hiddenLabels.remove': 'Remove search string',
+        'term.metadata.hiddenLabels.remove.text': 'Remove',
+        "term.metadata.hiddenLabels.help": "(Optional) search strings, which are not meant for visual presentation of terms and" +
+            " serve mainly for search engines. Search strings do not need to be (contextual) synonyms to the label. E.g. " +
+            "a term with label 'potato' can have search string 'spud'. ",
         'term.metadata.status': 'Status',
         'term.updated.message': 'Term successfully updated.',
         'term.metadata.labelExists.message': "Term with label \"{label}\" already exists in this vocabulary",

--- a/src/model/Term.ts
+++ b/src/model/Term.ts
@@ -7,6 +7,8 @@ import {BASE_CONTEXT as BASE_OCCURRENCE_CONTEXT, TermOccurrenceData} from "./Ter
 
 const ctx = {
     label: VocabularyUtils.SKOS_PREF_LABEL,
+    altLabels: VocabularyUtils.SKOS_ALT_LABEL,
+    hiddenLabels: VocabularyUtils.SKOS_HIDDEN_LABEL,
     definition: VocabularyUtils.DEFINITION,
     comment: VocabularyUtils.SKOS_SCOPE_NOTE,
     parentTerms: VocabularyUtils.BROADER,
@@ -21,11 +23,13 @@ const ctx = {
 
 export const CONTEXT = Object.assign(ctx, ASSET_CONTEXT, BASE_OCCURRENCE_CONTEXT);
 
-const MAPPED_PROPERTIES = ["@context", "iri", "label", "comment", "definition",
+const MAPPED_PROPERTIES = ["@context", "iri", "label", "altLabels", "hiddenLabels", "comment", "definition",
     "subTerms", "sources", "types", "parentTerms", "parent", "plainSubTerms", "vocabulary", "glossary", "definitionSource", "draft"];
 
 export interface TermData extends AssetData {
     label: string;
+    altLabels?: string[];
+    hiddenLabels?: string[];
     definition?: string;
     subTerms?: TermInfo[];
     sources?: string[];
@@ -45,6 +49,8 @@ export interface TermInfo {
 }
 
 export default class Term extends Asset implements TermData {
+    public altLabels?: string[];
+    public hiddenLabels?: string[];
     public definition?: string;
     public subTerms?: TermInfo[];
     public parentTerms?: Term[];

--- a/src/util/VocabularyUtils.ts
+++ b/src/util/VocabularyUtils.ts
@@ -51,6 +51,8 @@ export default {
     BROADER: _NS_SKOS + "broader",
     NARROWER: _NS_SKOS + "narrower",
     SKOS_PREF_LABEL: _NS_SKOS + "prefLabel",
+    SKOS_ALT_LABEL: _NS_SKOS + "altLabel",
+    SKOS_HIDDEN_LABEL: _NS_SKOS + "hiddenLabel",
     SKOS_SCOPE_NOTE: _NS_SKOS + "scopeNote",
     SKOS_IN_SCHEME: _NS_SKOS + "inScheme",
     IS_TERM_FROM_VOCABULARY: _NS_POPIS_DAT + "je-pojmem-ze-slovníku",


### PR DESCRIPTION
https://kbss.felk.cvut.cz/redmine/issues/1065

Included:
- altLabels as a part of the header of term detail screen
- altLabels + hiddenLabels editable in term detail edit
- hiddenLabels not part of the term detail view

Not Included:
- fulltext search results