### PR TITLE
[Bug #1358]

### DIFF
--- a/src/component/annotator/AnnotationDomHelper.ts
+++ b/src/component/annotator/AnnotationDomHelper.ts
@@ -47,13 +47,17 @@ export default {
             return foundResults[0] as DomHandlerElement;
         }
     },
-    removeAnnotation(annotation: DomHandlerNode): DomHandlerNode {
+
+    removeAnnotation(annotation: DomHandlerNode, dom: DomHandlerNode[]): void {
         // assuming annotation.type === "tag"
         const elem = annotation as DomHandlerElement;
         if (Utils.sanitizeArray(elem.children).length === 1 && elem.children![0].type === "text") {
             const newNode = this.createTextualNode(elem);
             DomUtils.replaceElement(elem, newNode);
-            return newNode;
+            const elemInd = dom.indexOf(elem);
+            if (elemInd !== -1) {
+                dom.splice(elemInd, 1, newNode);
+            }
         } else {
             // If the node is not just text, it contains other elements as well. In that case, just delete the
             // RDFa-specific attributes
@@ -62,7 +66,6 @@ export default {
             delete elem.attribs.property;
             delete elem.attribs.typeof;
             delete elem.attribs.class;
-            return elem;
         }
     },
 

--- a/src/component/annotator/Annotator.tsx
+++ b/src/component/annotator/Annotator.tsx
@@ -120,12 +120,12 @@ export class Annotator extends React.Component<AnnotatorProps, AnnotatorState> {
     };
 
     public onRemove = (annotationId: string | string[]) => {
-        const dom = [...this.state.internalHtml];
+        let dom = [...this.state.internalHtml];
         let removed = false;
         for (const id of Utils.sanitizeArray(annotationId)) {
             const ann = AnnotationDomHelper.findAnnotation(dom, id, this.state.prefixMap);
             if (ann) {
-                AnnotationDomHelper.removeAnnotation(ann);
+                AnnotationDomHelper.removeAnnotation(ann, dom);
                 removed = true;
             }
         }

--- a/src/component/annotator/__tests__/Annotator.test.tsx
+++ b/src/component/annotator/__tests__/Annotator.test.tsx
@@ -201,7 +201,7 @@ describe("Annotator", () => {
 
             wrapper.instance().onCloseCreate();
             expect(wrapper.state().newTermLabelAnnotation).not.toBeDefined();
-            expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledWith(annotation);
+            expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledWith(annotation, expect.anything());
         });
 
         // Bug #1245
@@ -233,7 +233,7 @@ describe("Annotator", () => {
 
             wrapper.instance().onCloseCreate();
             expect(wrapper.state().newTermDefinitionAnnotation).not.toBeDefined();
-            expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledWith(definitionAnnotation);
+            expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledWith(definitionAnnotation, expect.anything());
         });
 
         it("makes a shallow copy of parsed content to force its re-render when new term is created", () => {


### PR DESCRIPTION
Replace annotation node with text node in list of DOM nodes when it is a top level node on annotation removal.

https://kbss.felk.cvut.cz/redmine/issues/1358