### PR TITLE
[Bug #1349] Do not reset selected term in global store when tree select input is cleared in term detail.

### DIFF
--- a/src/component/term/Terms.tsx
+++ b/src/component/term/Terms.tsx
@@ -142,6 +142,9 @@ export class Terms extends React.Component<GlossaryTermsProps, TermsState> {
 
     public onTermSelect = (term: TermData | null) => {
         if (term === null) {
+            if (this.props.isDetailView) {
+                return;
+            }
             this.props.selectVocabularyTerm(term);
         } else {
             // The tree component adds depth and expanded attributes to the options when rendering,

--- a/src/component/term/__tests__/Terms.test.tsx
+++ b/src/component/term/__tests__/Terms.test.tsx
@@ -71,30 +71,39 @@ describe("Terms", () => {
         });
     });
 
-    it("transitions to term detail on term select", () => {
-        const wrapper = renderShallow();
-        (wrapper.instance()).onTermSelect(term);
-        const call = (Routing.transitionToAsset as jest.Mock).mock.calls[0];
-        expect(call[0].iri).toEqual(term.iri);
-        expect(call[0].vocabulary).toEqual(term.vocabulary);
-        expect(call[0].types).toEqual(term.types);
+    describe("onTermSelect", () => {
+        it("transitions to selected term detail", () => {
+            const wrapper = renderShallow();
+            (wrapper.instance()).onTermSelect(term);
+            const call = (Routing.transitionToAsset as jest.Mock).mock.calls[0];
+            expect(call[0].iri).toEqual(term.iri);
+            expect(call[0].vocabulary).toEqual(term.vocabulary);
+            expect(call[0].types).toEqual(term.types);
+        });
+
+        it("invokes term selected on term select", () => {
+            const wrapper = renderShallow();
+            wrapper.instance().onTermSelect(term);
+            expect(selectVocabularyTerm).toHaveBeenCalled();
+            expect((selectVocabularyTerm as jest.Mock).mock.calls[0][0].iri).toEqual(term.iri);
+        });
+
+        // Redmine #1349
+        it("does not invoke termSelected when rendered in term detail view and no term is selected (input is cleared)", () => {
+            const wrapper = renderShallow(true);
+            wrapper.instance().onTermSelect(null);
+            expect(selectVocabularyTerm).not.toHaveBeenCalled();
+        });
     });
 
-    function renderShallow() {
+    function renderShallow(isDetailView: boolean = false) {
         return shallow<Terms>(<Terms counter={counter} selectedTerms={selectedTerms}
                                      notifications={[]} consumeNotification={consumeNotification}
                                      selectVocabularyTerm={selectVocabularyTerm} vocabulary={vocabulary}
                                      fetchTerms={fetchTerms} {...intlFunctions()}
-                                     location={location} match={match}
+                                     location={location} match={match} isDetailView={isDetailView}
                                      fetchUnusedTerms={fetchUnusedTerms}/>);
     }
-
-    it("invokes term selected on term select", () => {
-        const wrapper = renderShallow();
-        wrapper.instance().onTermSelect(term);
-        expect(selectVocabularyTerm).toHaveBeenCalled();
-        expect((selectVocabularyTerm as jest.Mock).mock.calls[0][0].iri).toEqual(term.iri);
-    });
 
     it("fetches terms including imported when configured to", () => {
         const wrapper = renderShallow();


### PR DESCRIPTION
Fixes https://kbss.felk.cvut.cz/redmine/issues/1349