### PR TITLE
[Bug #1443] Remove term occurrence on term creation cancel only if it…

### DIFF
--- a/src/component/annotator/Annotation.tsx
+++ b/src/component/annotator/Annotation.tsx
@@ -169,7 +169,8 @@ export class Annotation extends React.Component<AnnotationProps, AnnotationState
             about: this.props.about,
             property: this.props.property,
             resource: this.props.resource,
-            typeof: this.props.typeof
+            typeof: this.props.typeof,
+            score: this.props.score
         };
         this.props.onCreateTerm(this.props.content ? this.props.content : this.props.text, newAnnotation);
     };

--- a/src/component/annotator/Annotator.tsx
+++ b/src/component/annotator/Annotator.tsx
@@ -186,8 +186,8 @@ export class Annotator extends React.Component<AnnotatorProps, AnnotatorState> {
 
     public onCloseCreate = () => {
         const toRemove: string[] = [];
-        if (this.state.newTermLabelAnnotation) {
-            toRemove.push(this.state.newTermLabelAnnotation.about!)
+        if (this.shouldRemoveLabelAnnotation()) {
+            toRemove.push(this.state.newTermLabelAnnotation!.about!)
         }
         if (this.state.newTermDefinitionAnnotation) {
             toRemove.push(this.state.newTermDefinitionAnnotation.about!);
@@ -199,6 +199,11 @@ export class Annotator extends React.Component<AnnotatorProps, AnnotatorState> {
             newTermDefinitionAnnotation: undefined
         });
     };
+
+    private shouldRemoveLabelAnnotation() {
+        const {newTermLabelAnnotation} = this.state;
+        return newTermLabelAnnotation && !newTermLabelAnnotation.score && !newTermLabelAnnotation.resource;
+    }
 
     private onMinimizeTermCreation = () => {
         this.props.publishMessage(new Message({messageId: "annotator.createTerm.selectDefinition.message"}, MessageType.INFO));

--- a/src/component/annotator/__tests__/Annotation.test.tsx
+++ b/src/component/annotator/__tests__/Annotation.test.tsx
@@ -276,7 +276,8 @@ describe("Annotation", () => {
                 about: assignedOccProps.about,
                 property: assignedOccProps.property,
                 typeof: assignedOccProps.typeof,
-                resource: assignedOccProps.resource
+                resource: assignedOccProps.resource,
+                score: assignedOccProps.score
             });
         });
 

--- a/src/component/annotator/__tests__/Annotator.test.tsx
+++ b/src/component/annotator/__tests__/Annotator.test.tsx
@@ -204,6 +204,49 @@ describe("Annotator", () => {
             expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledWith(annotation, expect.anything());
         });
 
+        // Bug #1443
+        it("does not remove suggested label occurrence when new term creation is cancelled", () => {
+            const wrapper = shallow<Annotator>(<Annotator fileIri={fileIri} vocabularyIri={vocabularyIri}
+                                                          {...mockedCallbackProps}
+                                                          initialHtml={generalHtmlContent}
+            />);
+            const annotation = {
+                about: "_:13",
+                content: "infrastruktura",
+                property: VocabularyUtils.IS_OCCURRENCE_OF_TERM,
+                typeof: VocabularyUtils.TERM_OCCURRENCE,
+                score: "1.0"
+            };
+            wrapper.instance().setState({newTermLabelAnnotation: annotation});
+            AnnotationDomHelper.findAnnotation = jest.fn().mockReturnValue(annotation);
+            AnnotationDomHelper.removeAnnotation = jest.fn();
+
+            wrapper.instance().onCloseCreate();
+            // Workaround for not.toHaveBeenCalled throwing an error
+            expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledTimes(0);
+        });
+
+        it("does not confirmed term label occurrence when new term creation is cancelled", () => {
+            const wrapper = shallow<Annotator>(<Annotator fileIri={fileIri} vocabularyIri={vocabularyIri}
+                                                          {...mockedCallbackProps}
+                                                          initialHtml={generalHtmlContent}
+            />);
+            const annotation = {
+                about: "_:13",
+                content: "infrastruktura",
+                property: VocabularyUtils.IS_OCCURRENCE_OF_TERM,
+                typeof: VocabularyUtils.TERM_OCCURRENCE,
+                resource: Generator.generateUri()
+            };
+            wrapper.instance().setState({newTermLabelAnnotation: annotation});
+            AnnotationDomHelper.findAnnotation = jest.fn().mockReturnValue(annotation);
+            AnnotationDomHelper.removeAnnotation = jest.fn();
+
+            wrapper.instance().onCloseCreate();
+            // Workaround for not.toHaveBeenCalled throwing an error
+            expect(AnnotationDomHelper.removeAnnotation).toHaveBeenCalledTimes(0);
+        });
+
         // Bug #1245
         it("removes created definition annotation when new term creation is cancelled", () => {
             const wrapper = shallow<Annotator>(<Annotator fileIri={fileIri} vocabularyIri={vocabularyIri}


### PR DESCRIPTION
… was not suggested or assigned an existing term.

Resolves https://kbss.felk.cvut.cz/redmine/issues/1443