### PR TITLE
[Bug #1492] Show tree select value as internal link where relevant.

### DIFF
--- a/config/server.json
+++ b/config/server.json
@@ -1,3 +1,3 @@
 {
-  "url": "https://kbss.felk.cvut.cz/termit-server-dev"
+  "url": "TO-BE-PROVIDED"
 }

--- a/config/server.json
+++ b/config/server.json
@@ -1,3 +1,3 @@
 {
-  "url": "TO-BE-PROVIDED"
+  "url": "https://kbss.felk.cvut.cz/termit-server-dev"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
-      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.13.tgz",
+      "integrity": "sha512-BPjEhhHe12QsV4k2iRNvP95yB1Gpjj6/NMmVP++5Yw295Se/ZVXPePV8cC5cZ6nrZBmmsQ9n0JmeUobM8TbskA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -7640,9 +7640,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
         }
       }
     },
@@ -11031,35 +11031,25 @@
       "dev": true
     },
     "intelligent-tree-select": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/intelligent-tree-select/-/intelligent-tree-select-0.7.9.tgz",
-      "integrity": "sha512-lkRrm+5k8DEKFlZfzAeuZVcyF7n3NLbeadAYvDLyej2CNPLiCohAx2b5Pero+DcsdNghrx1YSuo+ICwrz127QA==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/intelligent-tree-select/-/intelligent-tree-select-0.7.10.tgz",
+      "integrity": "sha512-0QXsA8ReG4saIF3BhBNUhoyBKPLcc9XMSdit3GgtiOKLmY3RAZXnZ1wgZpuiLqZ/EpO3gCQtL1vqGa3KDljV5g==",
       "requires": {
-        "bootstrap": "^4.5.3",
+        "bootstrap": "^4.6.0",
         "classnames": "^2.2.6",
-        "informed": "^1.10.8",
-        "react-highlight-words": "^0.16.0",
-        "react-input-autosize": "^2.2.2",
+        "informed": "^1.10.12",
+        "react-highlight-words": "^0.17.0",
+        "react-input-autosize": "^3.0.0",
         "react-select": "^1.3.0",
-        "react-virtualized": "^9.22.2",
+        "react-virtualized": "^9.22.3",
         "react-virtualized-select": "^3.1.3",
-        "reactstrap": "^8.7.1"
+        "reactstrap": "^8.9.0"
       },
       "dependencies": {
         "classnames": {
           "version": "2.2.6",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
           "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-        },
-        "react-highlight-words": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/react-highlight-words/-/react-highlight-words-0.16.0.tgz",
-          "integrity": "sha512-q34TwCSJOL+5pVDv6LUj3amaoyXdNDwd7zRqVAvceOrO9g1haWLAglK6WkGLMNUa3PFN8EgGedLg/k8Gpndxqg==",
-          "requires": {
-            "highlight-words-core": "^1.2.0",
-            "memoize-one": "^4.0.0",
-            "prop-types": "^15.5.8"
-          }
         }
       }
     },
@@ -16778,9 +16768,9 @@
       }
     },
     "react-input-autosize": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
-      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
+      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -16970,6 +16960,16 @@
         "classnames": "^2.2.4",
         "prop-types": "^15.5.8",
         "react-input-autosize": "^2.1.2"
+      },
+      "dependencies": {
+        "react-input-autosize": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+          "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+          "requires": {
+            "prop-types": "^15.5.8"
+          }
+        }
       }
     },
     "react-side-effect": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "domhandler": "^3.0.0",
     "html-to-react": "1.4.5",
     "htmlparser2": "^4.1.0",
-    "intelligent-tree-select": "0.7.9",
+    "intelligent-tree-select": "0.7.10",
     "iso-639-1": "^2.1.7",
     "javascript-time-ago": "2.3.4",
     "jquery": "^3.5.1",

--- a/src/component/annotator/AnnotationTerms.tsx
+++ b/src/component/annotator/AnnotationTerms.tsx
@@ -15,7 +15,7 @@ import {ThunkDispatch} from "../../util/Types";
 import {GoPlus} from "react-icons/go";
 import Utils from "../../util/Utils";
 import {commonTermTreeSelectProps, processTermsForTreeSelect} from "../term/TermTreeSelectHelper";
-import {createTermsWithImportsOptionRenderer} from "../misc/treeselect/Renderers";
+import {createTermsWithImportsOptionRenderer, createTermValueRenderer} from "../misc/treeselect/Renderers";
 
 interface GlossaryTermsProps extends HasI18n, RouteComponentProps<any> {
     vocabulary?: Vocabulary;
@@ -99,6 +99,7 @@ export class AnnotationTerms extends React.Component<AnnotationTermsProps> {
                 isMenuOpen={false}
                 multi={false}
                 optionRenderer={createTermsWithImportsOptionRenderer(this.props.vocabulary!.iri)}
+                valueRenderer={createTermValueRenderer()}
                 {...commonTermTreeSelectProps(this.props)}
             />
         </FormGroup>;

--- a/src/component/misc/treeselect/Renderers.tsx
+++ b/src/component/misc/treeselect/Renderers.tsx
@@ -5,6 +5,9 @@ import ResultItem from "./ResultItem";
 import ImportedTermInfo from "../../term/ImportedTermInfo";
 import UnusedTermInfo from "../../term/UnusedTermInfo";
 import TermQualityBadge from "../../term/TermQualityBadge";
+import TermLink from "../../term/TermLink";
+import Vocabulary from "../../../model/Vocabulary";
+import VocabularyLink from "../../vocabulary/VocabularyLink";
 
 interface TreeOption {
     disabled: boolean;
@@ -51,6 +54,7 @@ export function createTermsWithImportsOptionRendererAndUnusedTerms(unusedTerms: 
  *
  * @param unusedTerms List of identifiers of terms which are not used anywhere
  * @param currentVocabularyIri IRI of the current vocabulary, used to resolve whether term is imported
+ * @param qualityBadge Whether quality badge should be rendered or not
  */
 export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadge(unusedTerms: string[], currentVocabularyIri?: string, qualityBadge?: boolean) {
     return (params: OptionRendererParams<Term>) => {
@@ -80,8 +84,17 @@ export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadg
         </span>;
 
         return <ResultItem key={params.key} renderAsTree={params.renderAsTree} className={className} option={option}
-                           childrenKey="plainSubTerms" labelKey={params.labelKey} valueKey={params.valueKey} getOptionLabel={params.getOptionLabel}
+                           childrenKey="plainSubTerms" labelKey={params.labelKey} valueKey={params.valueKey}
+                           getOptionLabel={params.getOptionLabel}
                            style={optionStyle} searchString={params.searchString} addonBefore={addonBefore}
                            displayInfoOnHover={false} {...eventHandlers}/>;
     }
+}
+
+export function createTermValueRenderer() {
+    return (option: Term) => <TermLink term={option}/>;
+}
+
+export function createVocabularyValueRenderer() {
+    return (option: Vocabulary) => <VocabularyLink vocabulary={option}/>;
 }

--- a/src/component/public/term/Terms.tsx
+++ b/src/component/public/term/Terms.tsx
@@ -20,6 +20,8 @@ import {connect} from "react-redux";
 import TermItState from "../../../model/TermItState";
 import {selectVocabularyTerm} from "../../../action/SyncActions";
 import {loadPublicTerms} from "../../../action/AsyncPublicViewActions";
+import {getLocalized} from "../../../model/MultilingualString";
+import {getShortLocale} from "../../../util/IntlUtil";
 
 
 interface GlossaryTermsProps extends HasI18n {
@@ -143,6 +145,7 @@ export class Terms extends React.Component<GlossaryTermsProps, TermsState> {
                     multi={false}
                     maxHeight={Utils.calculateAssetListHeight()}
                     optionRenderer={createTermsWithImportsOptionRenderer(this.props.vocabulary.iri)}
+                    valueRenderer={(option: Term) => getLocalized(option.label, getShortLocale(this.props.locale))}
                     {...commonTermTreeSelectProps(this.props)}
                 />
             </div>

--- a/src/component/term/ParentTermSelector.tsx
+++ b/src/component/term/ParentTermSelector.tsx
@@ -12,7 +12,7 @@ import Utils from "../../util/Utils";
 // @ts-ignore
 import {IntelligentTreeSelect} from "intelligent-tree-select";
 import IncludeImportedTermsToggle from "./IncludeImportedTermsToggle";
-import {createTermsWithImportsOptionRenderer} from "../misc/treeselect/Renderers";
+import {createTermsWithImportsOptionRenderer, createTermValueRenderer} from "../misc/treeselect/Renderers";
 import Vocabulary from "../../model/Vocabulary";
 import TermItState from "../../model/TermItState";
 import CustomInput from "../misc/CustomInput";
@@ -142,7 +142,7 @@ export class ParentTermSelector extends React.Component<ParentTermSelectorProps,
         } else {
             let style;
             if (this.props.invalid) {
-                style = { borderColor : 'red' };
+                style = {borderColor: "red"};
             } else {
                 style = {}
             }
@@ -154,9 +154,11 @@ export class ParentTermSelector extends React.Component<ParentTermSelectorProps,
                                             maxHeight={200}
                                             multi={true}
                                             optionRenderer={createTermsWithImportsOptionRenderer(this.props.vocabularyIri)}
+                                            valueRenderer={createTermValueRenderer()}
                                             style={style}
                                             {...commonTermTreeSelectProps(this.props)}/>
-                {this.props.invalid ? <FormFeedback style={{display: 'block'}}>{this.props.invalidMessage}</FormFeedback> : <></>}
+                {this.props.invalid ?
+                    <FormFeedback style={{display: "block"}}>{this.props.invalidMessage}</FormFeedback> : <></>}
                 <FormText>{this.props.i18n("term.parent.help")}</FormText>
             </>;
         }

--- a/src/component/term/Terms.tsx
+++ b/src/component/term/Terms.tsx
@@ -22,9 +22,7 @@ import AppNotification from "../../model/AppNotification";
 import AsyncActionStatus from "../../action/AsyncActionStatus";
 import ActionType from "../../action/ActionType";
 import NotificationType from "../../model/NotificationType";
-import {
-    createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadge
-} from "../misc/treeselect/Renderers";
+import {createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadge} from "../misc/treeselect/Renderers";
 import IncludeImportedTermsToggle from "./IncludeImportedTermsToggle";
 import {commonTermTreeSelectProps, processTermsForTreeSelect} from "./TermTreeSelectHelper";
 import {Location} from "history";
@@ -32,6 +30,8 @@ import {match as Match} from "react-router";
 import classNames from "classnames";
 import StatusFilter from "./StatusFilter";
 import "./Terms.scss";
+import {getLocalized} from "../../model/MultilingualString";
+import {getShortLocale} from "../../util/IntlUtil";
 
 interface GlossaryTermsProps extends HasI18n {
     vocabulary?: Vocabulary;
@@ -252,6 +252,7 @@ export class Terms extends React.Component<GlossaryTermsProps, TermsState> {
                     multi={false}
                     maxHeight={Utils.calculateAssetListHeight()}
                     optionRenderer={createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadge(unusedTerms, this.props.vocabulary.iri, this.props.showTermQualityBadge)}
+                    valueRenderer={(option: Term) => getLocalized(option.label, getShortLocale(this.props.locale))}
                     {...commonTermTreeSelectProps(this.props)}
                 />
             </div>

--- a/src/component/vocabulary/ImportedVocabulariesListEdit.tsx
+++ b/src/component/vocabulary/ImportedVocabulariesListEdit.tsx
@@ -9,6 +9,7 @@ import {Col, FormGroup, Label, Row} from "reactstrap";
 import {connect} from "react-redux";
 import TermItState from "../../model/TermItState";
 import Utils from "../../util/Utils";
+import {createVocabularyValueRenderer} from "../misc/treeselect/Renderers";
 
 interface ImportedVocabulariesListEditProps extends HasI18n {
     vocabulary: Vocabulary;
@@ -46,7 +47,7 @@ export class ImportedVocabulariesListEdit extends React.Component<ImportedVocabu
                                            displayInfoOnHover={false}
                                            renderAsTree={false}
                                            simpleTreeData={true}
-                                           valueRenderer={Utils.labelValueRenderer}
+                                           valueRenderer={createVocabularyValueRenderer()}
                     />
                 </FormGroup>
             </Col>

--- a/src/component/vocabulary/VocabularySummary.tsx
+++ b/src/component/vocabulary/VocabularySummary.tsx
@@ -9,7 +9,7 @@ import {
     exportGlossary,
     loadVocabulary,
     removeVocabulary,
-    validateVocabulary, 
+    validateVocabulary,
     loadResource,
     updateVocabulary
 } from "../../action/AsyncActions";
@@ -38,7 +38,7 @@ import WindowTitle from "../misc/WindowTitle";
 interface VocabularySummaryProps extends HasI18n, RouteComponentProps<any> {
     vocabulary: Vocabulary;
     loadResource: (iri: IRI) => void;
-    loadVocabulary: (iri: IRI) => void;
+    loadVocabulary: (iri: IRI) => Promise<any>;
     updateVocabulary: (vocabulary: Vocabulary) => Promise<any>;
     removeVocabulary: (vocabulary: Vocabulary) => Promise<any>;
     validateVocabulary: (iri: IRI) => Promise<any>;
@@ -66,9 +66,12 @@ export class VocabularySummary extends EditableComponent<VocabularySummaryProps,
         this.loadVocabulary();
     }
 
-    public componentDidUpdate(): void {
+    public componentDidUpdate(prevProps: Readonly<VocabularySummaryProps>): void {
         if (this.props.vocabulary !== EMPTY_VOCABULARY) {
             this.loadVocabulary();
+        }
+        if (prevProps.vocabulary.iri !== this.props.vocabulary.iri) {
+            this.onCloseEdit();
         }
     }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -177,10 +177,6 @@ header .nav-tabs {
   font-weight: 700;
 }
 
-.m-asset-link {
-  line-height: 1.7;
-}
-
 .alert-dismissible {
   padding-right: 2.3rem !important;
 }


### PR DESCRIPTION
https://kbss.felk.cvut.cz/redmine/issues/1492

Tree select value is shown as internal link for:
- Vocabulary imports edit
- Term parent selector
- Term selector in annotator

There are two more occurrences of the tree select: 
- term type selector - has been left as is, so the link goes to the type IRI
- term selector in term detail - displays value as simple (non-clickable) label, since the user is already viewing the detail of the selected term.