### PR TITLE
[Bug #1587] Ensure subsequent navigation to the same file works correctly

### DIFF
--- a/src/component/resource/ResourceFileDetail.tsx
+++ b/src/component/resource/ResourceFileDetail.tsx
@@ -89,9 +89,11 @@ export class ResourceFileDetail extends React.Component<
   }
 
   private hasResourceIriChanged(prevProps: Readonly<ResourceFileDetailProps>) {
+    // Search needs to be decoded because it is automatically encoded by the browser (at least Chrome) on update
     return (
       this.props.match.params.fileName !== prevProps.match.params.fileName ||
-      this.props.location.search !== prevProps.location.search
+      decodeURIComponent(this.props.location.search) !==
+        decodeURIComponent(prevProps.location.search)
     );
   }
 

--- a/src/component/resource/__tests__/ResourceFileDetail.test.tsx
+++ b/src/component/resource/__tests__/ResourceFileDetail.test.tsx
@@ -388,7 +388,7 @@ describe("ResourceFileDetail", () => {
     );
   });
 
-  it("sets vocabulary in state to undefined to force its reload when namespace in URL changes", () => {
+  it("sets vocabulary IRI in state to undefined to force its reload when namespace in URL changes", () => {
     resource.owner = {
       vocabulary: { iri: Generator.generateUri() },
       iri: Generator.generateUri(),
@@ -415,5 +415,32 @@ describe("ResourceFileDetail", () => {
     wrapper.setProps({ match: newMatch });
     wrapper.update();
     expect(wrapper.state().vocabularyIri).not.toBeDefined();
+  });
+
+  // Bug #1587
+  it("does not reset vocabulary IRI when namespace is only encoded", () => {
+    resource.owner = {
+      vocabulary: { iri: Generator.generateUri() },
+      iri: Generator.generateUri(),
+      label: "Test document",
+      files: [resource],
+    };
+    const wrapper = shallow<ResourceFileDetail>(
+      <ResourceFileDetail
+        resource={resource}
+        routeTransitionPayload={{}}
+        loadResource={loadResource}
+        popRoutingPayload={popRoutingPayload}
+        loadLatestTextAnalysisRecord={loadLatestTextAnalysisRecord}
+        {...routeProps}
+        {...intlFunctions()}
+      />
+    );
+    expect(wrapper.state().vocabularyIri).toBeDefined();
+    const newSearch = "?fileNamespace=" + encodeURIComponent(resourceNamespace);
+    const newLocation = Object.assign({}, location, { search: newSearch });
+    wrapper.setProps({ location: newLocation });
+    wrapper.update();
+    expect(wrapper.state().vocabularyIri).toBeDefined();
   });
 });


### PR DESCRIPTION
https://kbss.felk.cvut.cz/redmine/issues/1587

This fixes the issue where repeated navigation to the same file (e.g. via the term definition source link) was ending with a  blank annotator screen. It was caused by the browser (Chrome) automatically encoding location.href, which is used by the `ResourceFileDetail` component to determine whether to reloaded the content or not.