### PR TITLE
[R-#1589] vocabulary name badge to distinguish term context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@formatjs/intl-pluralrules": "^4.0.22",
         "@formatjs/intl-relativetimeformat": "^9.1.2",
         "@fortawesome/fontawesome-free": "^5.15.3",
+        "@opendata-mvcr/assembly-line-shared": "^0.2.0",
         "apexcharts": "^3.26.3",
         "axios": "^0.21.1",
         "bootstrap": "4.6.0",
@@ -89,7 +90,7 @@
         "jest-react-hooks-shallow": "^1.5.1",
         "jest-watch-typeahead": "^0.6.3",
         "node-sass": "^6.0.0",
-        "prettier": "^2.3.0",
+        "prettier": "2.3.0",
         "raw.macro": "^0.4.2",
         "redux-devtools-extension": "^2.13.9",
         "redux-mock-store": "^1.5.4",
@@ -2504,6 +2505,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@opendata-mvcr/assembly-line-shared": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opendata-mvcr/assembly-line-shared/-/assembly-line-shared-0.2.0.tgz",
+      "integrity": "sha512-+08qDtLIeWntz+TB72b88zjs0XtLvv2M9moR24PUVwO5VsnaPiu9FXyJefs8WZ1QZ+QUMMX926mi65/hlIYVUg==",
+      "dependencies": {
+        "oidc-client": "^1.11.5",
+        "yaml": "^1.10.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -6468,6 +6481,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "node_modules/crypto-random-string": {
       "version": "1.0.0",
@@ -15119,6 +15137,18 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "node_modules/oidc-client": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
+      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -18233,19 +18263,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/react-scripts/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/react-select": {
@@ -26152,6 +26169,15 @@
         }
       }
     },
+    "@opendata-mvcr/assembly-line-shared": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opendata-mvcr/assembly-line-shared/-/assembly-line-shared-0.2.0.tgz",
+      "integrity": "sha512-+08qDtLIeWntz+TB72b88zjs0XtLvv2M9moR24PUVwO5VsnaPiu9FXyJefs8WZ1QZ+QUMMX926mi65/hlIYVUg==",
+      "requires": {
+        "oidc-client": "^1.11.5",
+        "yaml": "^1.10.2"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -29348,6 +29374,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -35980,6 +36011,18 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "oidc-client": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
+      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
+      "requires": {
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
+      }
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -38413,13 +38456,6 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
-        },
-        "type-fest": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-          "optional": true,
-          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@formatjs/intl-pluralrules": "^4.0.22",
     "@formatjs/intl-relativetimeformat": "^9.1.2",
     "@fortawesome/fontawesome-free": "^5.15.3",
+    "@opendata-mvcr/assembly-line-shared": "^0.2.0",
     "apexcharts": "^3.26.3",
     "axios": "^0.21.1",
     "bootstrap": "4.6.0",

--- a/src/component/annotator/AnnotationTerms.tsx
+++ b/src/component/annotator/AnnotationTerms.tsx
@@ -138,7 +138,7 @@ export class AnnotationTerms extends React.Component<AnnotationTermsProps> {
             optionRenderer={createTermsWithImportsOptionRenderer(
               this.props.vocabulary!.iri
             )}
-            valueRenderer={createTermValueRenderer()}
+            valueRenderer={createTermValueRenderer(this.props.vocabulary!.iri)}
             {...commonTermTreeSelectProps(this.props)}
           />
           <FormText>

--- a/src/component/misc/treeselect/Renderers.tsx
+++ b/src/component/misc/treeselect/Renderers.tsx
@@ -118,11 +118,11 @@ export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadg
     );
 
     const addonAfter = (
-        <span>
-          {!currentVocabularyIri ||
-          currentVocabularyIri === option.vocabulary!.iri ? undefined : (
-              <VocabularyNameBadge vocabulary={option.vocabulary} />
-          )}
+      <span>
+        {!currentVocabularyIri ||
+        currentVocabularyIri === option.vocabulary!.iri ? undefined : (
+          <VocabularyNameBadge vocabulary={option.vocabulary} />
+        )}
       </span>
     );
 
@@ -147,8 +147,15 @@ export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadg
   };
 }
 
-export function createTermValueRenderer( vocabularyIri: string ) {
-  return (option: Term) => <><TermLink term={option} />{vocabularyIri !== option.vocabulary?.iri ? <VocabularyNameBadge vocabulary={option.vocabulary}/> : null}</>;
+export function createTermValueRenderer(vocabularyIri: string) {
+  return (option: Term) => (
+    <>
+      <TermLink term={option} />
+      {vocabularyIri !== option.vocabulary?.iri ? (
+        <VocabularyNameBadge vocabulary={option.vocabulary} />
+      ) : null}
+    </>
+  );
 }
 
 export function createVocabularyValueRenderer() {

--- a/src/component/misc/treeselect/Renderers.tsx
+++ b/src/component/misc/treeselect/Renderers.tsx
@@ -7,6 +7,7 @@ import TermQualityBadge from "../../term/TermQualityBadge";
 import TermLink from "../../term/TermLink";
 import Vocabulary from "../../../model/Vocabulary";
 import VocabularyLink from "../../vocabulary/VocabularyLink";
+import VocabularyNameBadge from "../../vocabulary/VocabularyNameBadge";
 
 interface TreeOption {
   disabled: boolean;
@@ -116,6 +117,15 @@ export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadg
       </span>
     );
 
+    const addonAfter = (
+        <span>
+          {!currentVocabularyIri ||
+          currentVocabularyIri === option.vocabulary!.iri ? undefined : (
+              <VocabularyNameBadge vocabulary={option.vocabulary} />
+          )}
+      </span>
+    );
+
     return (
       <ResultItem
         key={params.key}
@@ -129,6 +139,7 @@ export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadg
         style={optionStyle}
         searchString={params.searchString}
         addonBefore={addonBefore}
+        addonAfter={addonAfter}
         displayInfoOnHover={false}
         {...eventHandlers}
       />
@@ -136,8 +147,8 @@ export function createTermsWithImportsOptionRendererAndUnusedTermsAndQualityBadg
   };
 }
 
-export function createTermValueRenderer() {
-  return (option: Term) => <TermLink term={option} />;
+export function createTermValueRenderer( vocabularyIri: string ) {
+  return (option: Term) => <><TermLink term={option} />{vocabularyIri !== option.vocabulary?.iri ? <VocabularyNameBadge vocabulary={option.vocabulary}/> : null}</>;
 }
 
 export function createVocabularyValueRenderer() {

--- a/src/component/term/BasicTermMetadata.tsx
+++ b/src/component/term/BasicTermMetadata.tsx
@@ -144,9 +144,9 @@ export class BasicTermMetadata extends React.Component<
             {list.map((item) => (
               <li key={item.iri}>
                 <TermLink term={item} language={this.props.language} />
-                {this.props.term.vocabulary !== item.vocabulary ?
-                    <VocabularyNameBadge vocabulary={item.vocabulary}/>
-                    : null}
+                {this.props.term.vocabulary !== item.vocabulary ? (
+                  <VocabularyNameBadge vocabulary={item.vocabulary} />
+                ) : null}
               </li>
             ))}
           </List>

--- a/src/component/term/BasicTermMetadata.tsx
+++ b/src/component/term/BasicTermMetadata.tsx
@@ -13,6 +13,7 @@ import TermLink from "./TermLink";
 import { OWL, SKOS } from "../../util/Namespaces";
 import { getLocalizedOrDefault } from "../../model/MultilingualString";
 import TermDefinitionBlock from "./TermDefinitionBlock";
+import VocabularyNameBadge from "../vocabulary/VocabularyNameBadge";
 
 interface BasicTermMetadataProps extends HasI18n {
   term: Term;
@@ -143,6 +144,9 @@ export class BasicTermMetadata extends React.Component<
             {list.map((item) => (
               <li key={item.iri}>
                 <TermLink term={item} language={this.props.language} />
+                {this.props.term.vocabulary !== item.vocabulary ?
+                    <VocabularyNameBadge vocabulary={item.vocabulary}/>
+                    : null}
               </li>
             ))}
           </List>

--- a/src/component/term/ExactMatchesSelector.tsx
+++ b/src/component/term/ExactMatchesSelector.tsx
@@ -15,7 +15,6 @@ import {
   createTermsWithImportsOptionRenderer,
   createTermValueRenderer,
 } from "../misc/treeselect/Renderers";
-import Vocabulary from "../../model/Vocabulary";
 import TermItState from "../../model/TermItState";
 import {
   commonTermTreeSelectProps,
@@ -47,7 +46,6 @@ interface ExactMatchesSelectorProps extends HasI18n {
   termIri?: string;
   selected?: TermData[];
   vocabularyIri: string;
-  currentVocabulary?: Vocabulary;
   onChange: (exactMatches: Term[]) => void;
   loadTerms: (
     fetchOptions: FetchOptionsFunction,
@@ -118,7 +116,7 @@ export class ExactMatchesSelector extends React.Component<ExactMatchesSelectorPr
             optionRenderer={createTermsWithImportsOptionRenderer(
               this.props.vocabularyIri
             )}
-            valueRenderer={createTermValueRenderer()}
+            valueRenderer={createTermValueRenderer(this.props.vocabularyIri)}
             {...commonTermTreeSelectProps(this.props)}
           />
         </>

--- a/src/component/term/ParentTermSelector.tsx
+++ b/src/component/term/ParentTermSelector.tsx
@@ -233,7 +233,7 @@ export class ParentTermSelector extends React.Component<
             optionRenderer={createTermsWithImportsOptionRenderer(
               this.props.vocabularyIri
             )}
-            valueRenderer={createTermValueRenderer()}
+            valueRenderer={createTermValueRenderer(this.props.vocabularyIri)}
             style={style}
             {...commonTermTreeSelectProps(this.props)}
           />

--- a/src/component/term/RelatedTermsSelector.tsx
+++ b/src/component/term/RelatedTermsSelector.tsx
@@ -25,6 +25,7 @@ import HelpIcon from "../misc/HelpIcon";
 interface RelatedTermsSelectorProps extends HasI18n {
   id: string;
   termIri?: string;
+  vocabularyIri: string;
   selected: TermInfo[];
   onChange: (value: Term[]) => void;
   loadTerms: (
@@ -86,8 +87,10 @@ export class RelatedTermsSelector extends React.Component<RelatedTermsSelectorPr
             searchDelay={300}
             maxHeight={200}
             multi={true}
-            optionRenderer={createTermsWithImportsOptionRenderer()}
-            valueRenderer={createTermValueRenderer()}
+            optionRenderer={createTermsWithImportsOptionRenderer(
+                this.props.vocabularyIri
+            )}
+            valueRenderer={createTermValueRenderer(this.props.vocabularyIri)}
             {...commonTermTreeSelectProps(this.props)}
           />
         </>

--- a/src/component/term/RelatedTermsSelector.tsx
+++ b/src/component/term/RelatedTermsSelector.tsx
@@ -88,7 +88,7 @@ export class RelatedTermsSelector extends React.Component<RelatedTermsSelectorPr
             maxHeight={200}
             multi={true}
             optionRenderer={createTermsWithImportsOptionRenderer(
-                this.props.vocabularyIri
+              this.props.vocabularyIri
             )}
             valueRenderer={createTermValueRenderer(this.props.vocabularyIri)}
             {...commonTermTreeSelectProps(this.props)}

--- a/src/component/term/TermMetadataEdit.tsx
+++ b/src/component/term/TermMetadataEdit.tsx
@@ -366,6 +366,7 @@ export class TermMetadataEdit extends React.Component<
                   <RelatedTermsSelector
                     id="edit-term-related"
                     termIri={this.props.term.iri}
+                    vocabularyIri={this.props.term.vocabulary?.iri!}
                     selected={Term.consolidateRelatedAndRelatedMatch(
                       this.state
                     )}

--- a/src/component/vocabulary/VocabularyNameBadge.scss
+++ b/src/component/vocabulary/VocabularyNameBadge.scss
@@ -1,0 +1,3 @@
+.vocabulary-name-badge {
+    min-width: 6.5rem;
+}

--- a/src/component/vocabulary/VocabularyNameBadge.scss
+++ b/src/component/vocabulary/VocabularyNameBadge.scss
@@ -1,3 +1,3 @@
 .vocabulary-name-badge {
-    min-width: 6.5rem;
+  min-width: 6.5rem;
 }

--- a/src/component/vocabulary/VocabularyNameBadge.tsx
+++ b/src/component/vocabulary/VocabularyNameBadge.tsx
@@ -1,31 +1,29 @@
 import * as React from "react";
-import {AssetData} from "../../model/Asset";
-import {getVocabularyShortLabel} from "@opendata-mvcr/assembly-line-shared";
-import {Badge} from "reactstrap";
+import { AssetData } from "../../model/Asset";
+import { getVocabularyShortLabel } from "@opendata-mvcr/assembly-line-shared";
+import { Badge } from "reactstrap";
 import classNames from "classnames";
 import "./VocabularyNameBadge.scss";
 
 interface VocabularyNameBadgeProps {
-    vocabulary?: AssetData;
-    className?: string;
+  vocabulary?: AssetData;
+  className?: string;
 }
 
 const VocabularyNameBadge: React.FC<VocabularyNameBadgeProps> = (props) => {
-    const {vocabulary, className} = props;
-    if (!vocabulary) {
-        return null;
-    }
-    return (
-        <Badge
-            color="info"
-            pill={true}
-            className={classNames("vocabulary-name-badge", className)}
-        >
-            {getVocabularyShortLabel(vocabulary.iri!)}
-        </Badge>
-    );
+  const { vocabulary, className } = props;
+  if (!vocabulary) {
+    return null;
+  }
+  return (
+    <Badge
+      color="info"
+      pill={true}
+      className={classNames("vocabulary-name-badge", className)}
+    >
+      {getVocabularyShortLabel(vocabulary.iri!)}
+    </Badge>
+  );
 };
 
 export default VocabularyNameBadge;
-
-

--- a/src/component/vocabulary/VocabularyNameBadge.tsx
+++ b/src/component/vocabulary/VocabularyNameBadge.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import {AssetData} from "../../model/Asset";
+import {getVocabularyShortLabel} from "@opendata-mvcr/assembly-line-shared";
+import {Badge} from "reactstrap";
+import classNames from "classnames";
+import "./VocabularyNameBadge.scss";
+
+interface VocabularyNameBadgeProps {
+    vocabulary?: AssetData;
+    className?: string;
+}
+
+const VocabularyNameBadge: React.FC<VocabularyNameBadgeProps> = (props) => {
+    const {vocabulary, className} = props;
+    if (!vocabulary) {
+        return null;
+    }
+    return (
+        <Badge
+            color="info"
+            pill={true}
+            className={classNames("vocabulary-name-badge", className)}
+        >
+            {getVocabularyShortLabel(vocabulary.iri!)}
+        </Badge>
+    );
+};
+
+export default VocabularyNameBadge;
+
+


### PR DESCRIPTION
- vocabulary/term/document IRIs changed according to the SGoV Scheme in IPR dev/prod
- added vocabulary name badge to exact/related/broader selectors + to the term detail panel - a badge shows up when the term comes from a different vocabulary than the vocabulary of the current term.
- can be tested on https://deploy-preview-179--termit-dev.netlify.app/#/vocabularies/building-act-no183-2006/terms/stavba?namespace=http://onto.fel.cvut.cz/ontologies/slovnik/ and in the respective Edit form.