### PR TITLE
Bug/related terms selector empty

### DIFF
--- a/src/component/annotator/CreateTermFromAnnotation.tsx
+++ b/src/component/annotator/CreateTermFromAnnotation.tsx
@@ -80,7 +80,7 @@ export class CreateTermFromAnnotation extends React.Component<
   };
 
   public onCancel = () => {
-    this.setState(AssetFactory.createEmptyTermData());
+    this.setState(AssetFactory.createEmptyTermData(this.props.language));
     this.props.onClose();
   };
 

--- a/src/component/term/ExactMatchesSelector.tsx
+++ b/src/component/term/ExactMatchesSelector.tsx
@@ -96,7 +96,6 @@ export class ExactMatchesSelector extends React.Component<ExactMatchesSelectorPr
             value={resolveSelectedIris(this.props.selected)}
             fetchOptions={this.fetchOptions}
             fetchLimit={300}
-            searchDelay={300}
             maxHeight={200}
             multi={true}
             optionRenderer={createTermsWithImportsOptionRenderer(

--- a/src/component/term/ParentTermSelector.tsx
+++ b/src/component/term/ParentTermSelector.tsx
@@ -216,7 +216,6 @@ export class ParentTermSelector extends React.Component<
             value={resolveSelectedIris(this.props.parentTerms)}
             fetchOptions={this.fetchOptions}
             fetchLimit={300}
-            searchDelay={300}
             maxHeight={200}
             multi={true}
             optionRenderer={createTermsWithImportsOptionRenderer(

--- a/src/component/term/RelatedTermsSelector.tsx
+++ b/src/component/term/RelatedTermsSelector.tsx
@@ -85,7 +85,6 @@ export class RelatedTermsSelector extends React.Component<RelatedTermsSelectorPr
             value={value}
             fetchOptions={this.fetchOptions}
             fetchLimit={100}
-            searchDelay={300}
             maxHeight={200}
             multi={true}
             optionRenderer={createTermsWithImportsOptionRenderer(

--- a/src/component/term/TermTreeSelectHelper.ts
+++ b/src/component/term/TermTreeSelectHelper.ts
@@ -27,6 +27,7 @@ export function commonTermTreeSelectProps(intl: HasI18n) {
 export type TermTreeSelectProcessingOptions = {
   searchString?: string;
   selectedIris?: string[];
+  loadingSubTerms?: boolean;
 };
 
 /**
@@ -68,7 +69,9 @@ export function processTermsForTreeSelect(
       );
     }
   }
-  addAncestorsOfSelected(Utils.sanitizeArray(options.selectedIris), result);
+  if (!options.loadingSubTerms) {
+    addAncestorsOfSelected(Utils.sanitizeArray(options.selectedIris), result);
+  }
   return result;
 }
 
@@ -216,6 +219,7 @@ export function loadAndPrepareTerms(
       processTermsForTreeSelect(terms, postOptions.matchingVocabularies, {
         searchString: fetchOptions.searchString,
         selectedIris,
+        loadingSubTerms: !!fetchOptions.optionID,
       })
     );
 }

--- a/src/component/term/TermTreeSelectHelper.ts
+++ b/src/component/term/TermTreeSelectHelper.ts
@@ -107,16 +107,21 @@ function flattenAncestors(terms: Term[]): Term[] {
  * are included explicitly in the results. If such an included result is not a top-level concept, it may not be displayed by the
  * tree component because it may have ancestors which are not in the first page retrieved for the tree component as well. This function
  * ensures that such a top-level ancestor is added to the result array so that the tree component can see it.
+ *
+ * Note that the  traversal is done in reverse, because it may happen that the root ancestor we are looking for occurs in the
+ * options twice - once loaded by default by the query and the second time loaded as part of the includedTerms' ancestors. In this case,
+ * the first occurrence does not contain and subterms, which causes the selected term not to be displayed in the selector.
  * @param selectedIris Identifiers of selected terms
  * @param options Options loaded from the server for display by the tree component
  */
 function addAncestorsOfSelected(selectedIris: string[], options: Term[]): void {
   selectedIris.forEach((iri) => {
-    const matching = options.find((t) => t.iri === iri);
-    if (!matching) {
-      return;
+    for (let i = options.length - 1; i >= 0; i--) {
+      if (options[i].iri === iri) {
+        traverseToAncestor(options[i], options);
+        return;
+      }
     }
-    traverseToAncestor(matching, options);
   });
 }
 

--- a/src/component/term/TermTreeSelectHelper.ts
+++ b/src/component/term/TermTreeSelectHelper.ts
@@ -21,6 +21,7 @@ export function commonTermTreeSelectProps(intl: HasI18n) {
     showSettings: false,
     noResultsText: intl.i18n("main.search.no-results"),
     placeholder: "",
+    searchDelay: 300,
   };
 }
 

--- a/src/component/term/__tests__/TermTreeSelectHelper.test.ts
+++ b/src/component/term/__tests__/TermTreeSelectHelper.test.ts
@@ -78,6 +78,21 @@ describe("TermTreeSelectHelper", () => {
       expect(parent!.subTerms).toBeDefined();
       expect(parent!.subTerms!.length).toBeGreaterThan(0);
     });
+
+    it("does not add top level ancestor of a selected term into the results when subterms of a term are being loaded", () => {
+      const terms = [Generator.generateTerm(vocUri)];
+      const included = Generator.generateTerm(vocUri);
+      const parent = Generator.generateTerm(vocUri);
+      included.parentTerms = [parent];
+      const grandParent = Generator.generateTerm();
+      parent.parentTerms = [grandParent];
+      terms.push(included);
+      const result = processTermsForTreeSelect(terms, [vocUri], {
+        selectedIris: [included.iri],
+        loadingSubTerms: true,
+      });
+      expect(result).not.toContain(grandParent);
+    });
   });
 
   describe("loadAndPrepareTerms", () => {


### PR DESCRIPTION
Fixes an issue with displaying related terms in edit screen reported by IPR on Slack.