### PR TITLE
[#318] Snapshot comments fetching via API

### DIFF
--- a/src/action/AsyncCommentActions.ts
+++ b/src/action/AsyncCommentActions.ts
@@ -15,13 +15,21 @@ import Comment, {
 } from "../model/Comment";
 import { ErrorData } from "../model/ErrorInfo";
 
-export function loadTermComments(termIri: IRI) {
+export function loadTermComments(
+  termIri: IRI,
+  dateTo?: string,
+  dateFrom?: string
+) {
   const action = { type: ActionType.LOAD_COMMENTS };
   return (dispatch: ThunkDispatch) => {
     dispatch(asyncActionRequest(action, true));
+    const reqParams: any = {};
+    reqParams.namespace = termIri.namespace;
+    if (dateTo) reqParams.to = dateTo;
+    if (dateFrom) reqParams.from = dateFrom;
     return Ajax.get(
       `${Constants.API_PREFIX}/terms/${termIri.fragment}/comments`,
-      param("namespace", termIri.namespace)
+      params(reqParams)
     )
       .then((data: object) =>
         JsonLdUtils.compactAndResolveReferencesAsArray<CommentData>(

--- a/src/action/AsyncCommentActions.ts
+++ b/src/action/AsyncCommentActions.ts
@@ -25,8 +25,8 @@ export function loadTermComments(
     dispatch(asyncActionRequest(action, true));
     const reqParams: any = {};
     reqParams.namespace = termIri.namespace;
-    if (dateTo) reqParams.to = dateTo;
-    if (dateFrom) reqParams.from = dateFrom;
+    reqParams.to = dateTo;
+    reqParams.from = dateFrom;
     return Ajax.get(
       `${Constants.API_PREFIX}/terms/${termIri.fragment}/comments`,
       params(reqParams)

--- a/src/component/comment/Comments.tsx
+++ b/src/component/comment/Comments.tsx
@@ -35,27 +35,17 @@ const Comments: React.FC<CommentsProps> = ({
   const dispatch: ThunkDispatch = useDispatch();
 
   React.useEffect(() => {
+    let assetIri = VocabularyUtils.create(term.iri);
+    let dateTo;
     //Check if term is a snapshot
     if (term.snapshotOf()) {
-      const snapshotTimeCreated = Date.parse(term.snapshotCreated()!);
-      dispatch(
-        loadTermComments(VocabularyUtils.create(term.snapshotOf()!))
-      ).then((data) => {
-        //Show comments which are relevant to the snapshot
-        const filteredComments = data.filter(
-          (r) => Date.parse(r.created!) < snapshotTimeCreated
-        );
-        setComments(filteredComments);
-        onLoad(filteredComments.length);
-      });
-    } else {
-      dispatch(loadTermComments(VocabularyUtils.create(term.iri))).then(
-        (data) => {
-          setComments(data);
-          onLoad(data.length);
-        }
-      );
+      assetIri = VocabularyUtils.create(term.snapshotOf()!);
+      dateTo = term.snapshotCreated();
     }
+    dispatch(loadTermComments(assetIri, dateTo)).then((data) => {
+      setComments(data);
+      onLoad(data.length);
+    });
   }, [dispatch, setComments, onLoad, term]);
   const termIri = VocabularyUtils.create(term.iri);
   const onSubmit = (comment: Comment) =>


### PR DESCRIPTION
Comments for snapshotted terms are now fetched via specific API call. 

Resolves: #318 