### PR TITLE
[#128] Rename document and files

### DIFF
--- a/src/action/AsyncActions.ts
+++ b/src/action/AsyncActions.ts
@@ -332,45 +332,6 @@ export function removeFileFromDocument(file: TermItFile, documentIri: IRI) {
   };
 }
 
-export function updateFileInDocument(file: TermItFile, documentIri: IRI) {
-  const action = {
-    type: ActionType.UPDATE_RESOURCE,
-  };
-  return (dispatch: ThunkDispatch) => {
-    dispatch(asyncActionRequest(action));
-    const fileIri = VocabularyUtils.create(file.iri);
-    const fileCopy = new TermItFile(file);
-    //owner was causing an err in JsonLd serialisation
-    delete fileCopy.owner;
-    return Ajax.put(
-      Constants.API_PREFIX +
-        "/resources/" +
-        documentIri.fragment +
-        "/files/" +
-        fileIri.fragment,
-      content(fileCopy.toJsonLd()).param("namespace", fileIri.namespace)
-    )
-      .then(() => {
-        dispatch(asyncActionSuccess(action));
-        dispatch(loadResource(documentIri));
-        dispatch(
-          SyncActions.publishMessage(
-            new Message(
-              { messageId: "resource.updated.message" },
-              MessageType.SUCCESS
-            )
-          )
-        );
-      })
-      .catch((error: ErrorData) => {
-        dispatch(asyncActionFailure(action, error));
-        dispatch(
-          SyncActions.publishMessage(new Message(error, MessageType.ERROR))
-        );
-      });
-  };
-}
-
 export function uploadFileContent(fileIri: IRI, data: File) {
   const action = {
     type: ActionType.SAVE_FILE_CONTENT,

--- a/src/component/asset/RenameFileDialog.tsx
+++ b/src/component/asset/RenameFileDialog.tsx
@@ -23,10 +23,6 @@ const RenameFileDialog: React.FC<RenameFileDialogProps> = (props) => {
 
   const [label, setLabel] = useState(props.asset.getLabel());
 
-  const setFileLabel = (label: string) => {
-    setLabel(label);
-  };
-
   const onConfirmHandler = () => {
     props.onSubmit(label);
   };
@@ -47,7 +43,7 @@ const RenameFileDialog: React.FC<RenameFileDialogProps> = (props) => {
         name="edit-file-label"
         label={i18n("asset.label")}
         value={label}
-        onChange={(e) => setFileLabel(e.currentTarget.value)}
+        onChange={(e) => setLabel(e.currentTarget.value)}
       />
     </ConfirmCancelDialog>
   );

--- a/src/component/asset/RenameFileDialog.tsx
+++ b/src/component/asset/RenameFileDialog.tsx
@@ -8,7 +8,7 @@ import Utils from "../../util/Utils";
 
 interface RenameFileDialogProps {
   show: boolean;
-  onSubmit: () => void;
+  onSubmit: (label: string) => void;
   onCancel: () => void;
   asset: TermItFile;
 }
@@ -20,12 +20,15 @@ const RenameFileDialog: React.FC<RenameFileDialogProps> = (props) => {
   const typeLabel = i18n(
     typeLabelId ? typeLabelId : "type.asset"
   ).toLowerCase();
-  const [labelOriginal] = useState(props.asset.getLabel());
+
   const [label, setLabel] = useState(props.asset.getLabel());
 
   const setFileLabel = (label: string) => {
-    props.asset.label = label;
     setLabel(label);
+  };
+
+  const onConfirmHandler = () => {
+    props.onSubmit(label);
   };
 
   return (
@@ -33,19 +36,18 @@ const RenameFileDialog: React.FC<RenameFileDialogProps> = (props) => {
       show={props.show}
       id="rename-asset"
       onClose={props.onCancel}
-      onConfirm={props.onSubmit}
+      onConfirm={onConfirmHandler}
       title={formatMessage("asset.rename.dialog.title", {
         type: typeLabel,
-        label: labelOriginal,
+        label: props.asset.getLabel(),
       })}
-      confirmKey="edit"
+      confirmKey="save"
     >
       <CustomInput
         name="edit-file-label"
         label={i18n("asset.label")}
         value={label}
         onChange={(e) => setFileLabel(e.currentTarget.value)}
-        hint={i18n("required")}
       />
     </ConfirmCancelDialog>
   );

--- a/src/component/asset/RenameFileDialog.tsx
+++ b/src/component/asset/RenameFileDialog.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { useI18n } from "../hook/useI18n";
+import ConfirmCancelDialog from "../misc/ConfirmCancelDialog";
+import TermItFile from "../../model/File";
+import { useState } from "react";
+import CustomInput from "../misc/CustomInput";
+import Utils from "../../util/Utils";
+
+interface RenameFileDialogProps {
+  show: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+  asset: TermItFile;
+}
+
+const RenameFileDialog: React.FC<RenameFileDialogProps> = (props) => {
+  const { i18n, formatMessage } = useI18n();
+
+  const typeLabelId = Utils.getAssetTypeLabelId(props.asset);
+  const typeLabel = i18n(
+    typeLabelId ? typeLabelId : "type.asset"
+  ).toLowerCase();
+  const [labelOriginal] = useState(props.asset.getLabel());
+  const [label, setLabel] = useState(props.asset.getLabel());
+
+  const setFileLabel = (label: string) => {
+    props.asset.label = label;
+    setLabel(label);
+  };
+
+  return (
+    <ConfirmCancelDialog
+      show={props.show}
+      id="rename-asset"
+      onClose={props.onCancel}
+      onConfirm={props.onSubmit}
+      title={formatMessage("asset.rename.dialog.title", {
+        type: typeLabel,
+        label: labelOriginal,
+      })}
+      confirmKey="edit"
+    >
+      <CustomInput
+        name="edit-file-label"
+        label={i18n("asset.label")}
+        value={label}
+        onChange={(e) => setFileLabel(e.currentTarget.value)}
+        hint={i18n("required")}
+      />
+    </ConfirmCancelDialog>
+  );
+};
+
+export default RenameFileDialog;

--- a/src/component/resource/document/DocumentFiles.tsx
+++ b/src/component/resource/document/DocumentFiles.tsx
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import {
   createFileInDocument,
   removeFileFromDocument,
-  updateFileInDocument,
+  updateResource,
   uploadFileContent,
 } from "../../../action/AsyncActions";
 import VocabularyUtils from "../../../util/VocabularyUtils";
@@ -18,12 +18,13 @@ import AddFile from "./AddFile";
 import FileContentLink from "../file/FileContentLink";
 import RemoveFile from "./RemoveFile";
 import RenameFile from "./RenameFile";
+import Resource from "../../../model/Resource";
 
 interface DocumentFilesProps {
   document: Document;
   removeFile: (file: TermItFile, documentIri: string) => Promise<void>;
   onFileRemoved: () => void;
-  renameFile: (file: TermItFile, documentIri: string) => Promise<void>;
+  renameFile: (file: TermItFile) => Promise<Resource | null>;
   onFileRenamed: () => void;
   addFile: (file: TermItFile, documentIri: string) => Promise<any>;
   onFileAdded: () => void;
@@ -64,8 +65,8 @@ export const DocumentFiles = (props: DocumentFilesProps) => {
 
   const modifyFile = useCallback(
     (termitFile: TermItFile): Promise<void> =>
-      renameFile(termitFile, document.iri).then(onFileRenamed),
-    [document, onFileRenamed, renameFile]
+      renameFile(new TermItFile(termitFile)).then(onFileRenamed),
+    [onFileRenamed, renameFile]
   );
 
   if (!document) {
@@ -102,7 +103,6 @@ export default connect(undefined, (dispatch: ThunkDispatch) => {
       dispatch(uploadFileContent(VocabularyUtils.create(fileIri), file)),
     notify: (notification: AppNotification) =>
       dispatch(publishNotification(notification)),
-    renameFile: (file: TermItFile, documentIri: string) =>
-      dispatch(updateFileInDocument(file, VocabularyUtils.create(documentIri))),
+    renameFile: (file: TermItFile) => dispatch(updateResource(file)),
   };
 })(DocumentFiles);

--- a/src/component/resource/document/DocumentFiles.tsx
+++ b/src/component/resource/document/DocumentFiles.tsx
@@ -84,12 +84,7 @@ export const DocumentFiles = (props: DocumentFilesProps) => {
           performAction={deleteFile.bind(this, file)}
           withConfirmation={true}
         />,
-        <RenameFile
-          key="rename-file"
-          file={file.clone()}
-          performAction={modifyFile}
-          withConfirmation={true}
-        />,
+        <RenameFile key="rename-file" file={file} performAction={modifyFile} />,
       ]}
     />
   );

--- a/src/component/resource/document/DocumentFiles.tsx
+++ b/src/component/resource/document/DocumentFiles.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import Document from "../../../model/Document";
-import TermItFile from "../../../model/File";
+import TermItFile, { FileData } from "../../../model/File";
 import { ThunkDispatch } from "../../../util/Types";
 import { connect } from "react-redux";
 import {
@@ -64,7 +64,7 @@ export const DocumentFiles = (props: DocumentFilesProps) => {
   );
 
   const modifyFile = useCallback(
-    (termitFile: TermItFile): Promise<void> =>
+    (termitFile: FileData): Promise<void> =>
       renameFile(new TermItFile(termitFile)).then(onFileRenamed),
     [onFileRenamed, renameFile]
   );

--- a/src/component/resource/document/DocumentSummary.tsx
+++ b/src/component/resource/document/DocumentSummary.tsx
@@ -21,7 +21,6 @@ const DocumentSummary: React.FC<DocumentSummaryProps> = ({
     dispatch(loadResource(VocabularyUtils.create(document!.iri))).then(
       onChange
     );
-
   return document ? (
     <div className="metadata-panel">
       <ResourceMetadata resource={document} inTab={true} />
@@ -29,6 +28,7 @@ const DocumentSummary: React.FC<DocumentSummaryProps> = ({
         document={document}
         onFileAdded={reload}
         onFileRemoved={reload}
+        onFileRenamed={reload}
       />
     </div>
   ) : null;

--- a/src/component/resource/document/RenameFile.tsx
+++ b/src/component/resource/document/RenameFile.tsx
@@ -8,7 +8,6 @@ import RenameFileDialog from "../../asset/RenameFileDialog";
 
 interface RenameFileProps {
   performAction: (file: TermItFile) => Promise<void>;
-  withConfirmation: boolean;
   file: TermItFile;
 }
 
@@ -17,8 +16,9 @@ export const RenameFile = (props: RenameFileProps) => {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
   const toggle = () => setConfirmationDialogOpen(!confirmationDialogOpen);
 
-  const performAction = () => {
-    props.performAction(props.file).then(toggle);
+  const performAction = (label: string) => {
+    const modifiedFile = Object.assign({}, props.file, { label: label.trim() });
+    props.performAction(modifiedFile).then(toggle);
   };
   return (
     <IfUserIsEditor>
@@ -28,12 +28,7 @@ export const RenameFile = (props: RenameFileProps) => {
         show={confirmationDialogOpen}
         asset={props.file}
       />
-      <Button
-        color="success"
-        size="sm"
-        onClick={props.withConfirmation ? toggle : performAction}
-        title={i18n("edit")}
-      >
+      <Button color="success" size="sm" onClick={toggle} title={i18n("edit")}>
         <GoPencil className="mr-1" />
         {i18n("edit")}
       </Button>

--- a/src/component/resource/document/RenameFile.tsx
+++ b/src/component/resource/document/RenameFile.tsx
@@ -1,0 +1,44 @@
+import { useI18n } from "../../hook/useI18n";
+import { useState } from "react";
+import IfUserIsEditor from "../../authorization/IfUserIsEditor";
+import { Button } from "reactstrap";
+import { GoPencil } from "react-icons/go";
+import TermItFile from "../../../model/File";
+import RenameFileDialog from "../../asset/RenameFileDialog";
+
+interface RenameFileProps {
+  performAction: (file: TermItFile) => Promise<void>;
+  withConfirmation: boolean;
+  file: TermItFile;
+}
+
+export const RenameFile = (props: RenameFileProps) => {
+  const { i18n } = useI18n();
+  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
+  const toggle = () => setConfirmationDialogOpen(!confirmationDialogOpen);
+
+  const performAction = () => {
+    props.performAction(props.file).then(toggle);
+  };
+  return (
+    <IfUserIsEditor>
+      <RenameFileDialog
+        onCancel={toggle}
+        onSubmit={performAction}
+        show={confirmationDialogOpen}
+        asset={props.file}
+      />
+      <Button
+        color="success"
+        size="sm"
+        onClick={props.withConfirmation ? toggle : performAction}
+        title={i18n("edit")}
+      >
+        <GoPencil className="mr-1" />
+        {i18n("edit")}
+      </Button>
+    </IfUserIsEditor>
+  );
+};
+
+export default RenameFile;

--- a/src/component/vocabulary/CreateVocabulary.tsx
+++ b/src/component/vocabulary/CreateVocabulary.tsx
@@ -35,6 +35,7 @@ import RemoveFile from "../resource/document/RemoveFile";
 import WindowTitle from "../misc/WindowTitle";
 import MarkdownEditor from "../misc/MarkdownEditor";
 import Constants from "../../util/Constants";
+import * as React from "react";
 
 interface CreateVocabularyProps extends HasI18n {
   createFile: (file: TermItFile, documentIri: string) => Promise<any>;
@@ -49,6 +50,7 @@ interface CreateAllVocabulariesState extends AbstractCreateAssetState {
   files: TermItFile[];
   fileContents: File[];
   showCreateFile: boolean;
+  documentLabel: string;
 }
 
 export class CreateVocabulary extends AbstractCreateAsset<
@@ -65,6 +67,7 @@ export class CreateVocabulary extends AbstractCreateAsset<
       files: [],
       fileContents: [],
       showCreateFile: false,
+      documentLabel: "",
     };
   }
 
@@ -83,9 +86,12 @@ export class CreateVocabulary extends AbstractCreateAsset<
     const files = this.state.files;
     const fileContents = this.state.fileContents;
     const document = new Document({
-      label: this.props.formatMessage("vocabulary.document.label", {
-        vocabulary: vocabulary.getLabel(),
-      }),
+      label:
+        this.state.documentLabel.trim() === ""
+          ? this.props.formatMessage("vocabulary.document.label", {
+              vocabulary: vocabulary.getLabel(),
+            })
+          : this.state.documentLabel.trim(),
       iri: this.state.iri + "/document",
       files: [],
     });
@@ -123,6 +129,13 @@ export class CreateVocabulary extends AbstractCreateAsset<
 
   private onCommentChange = (value: string): void => {
     this.setState({ comment: value });
+  };
+
+  private onDocumentLabelChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    const label = e.currentTarget.value;
+    this.setState({ documentLabel: label });
   };
 
   private isFormValid() {
@@ -198,6 +211,16 @@ export class CreateVocabulary extends AbstractCreateAsset<
                     </Col>
                   </Row>
                 </ShowAdvanceAssetFields>
+                <Row>
+                  <Col xs={12}>
+                    <CustomInput
+                      name="edit-document-label"
+                      label={i18n("vocabulary.document.set.label")}
+                      value={this.state.documentLabel}
+                      onChange={this.onDocumentLabelChange}
+                    />
+                  </Col>
+                </Row>
                 <Files
                   files={this.state.files}
                   actions={[

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -62,7 +62,7 @@ export class VocabularyEdit extends React.Component<
 
   public onSave = () => {
     const modifiedDocument = Object.assign({}, this.props.vocabulary.document, {
-      label: this.state.documentLabel.trim(),
+      label: this.state.documentLabel?.trim(),
     });
 
     const newVocabulary = new Vocabulary(

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -18,11 +18,13 @@ import ImportedVocabulariesListEdit from "./ImportedVocabulariesListEdit";
 import { AssetData } from "../../model/Asset";
 import MarkdownEditor from "../misc/MarkdownEditor";
 import Constants from "../../util/Constants";
+import Document from "../../model/Document";
 
 interface VocabularyEditProps extends HasI18n {
   vocabulary: Vocabulary;
   save: (vocabulary: Vocabulary) => void;
   cancel: () => void;
+  saveDocument: (document: Document) => void;
 }
 
 interface VocabularyEditState {
@@ -68,10 +70,10 @@ export class VocabularyEdit extends React.Component<
         label: this.state.label,
         comment: this.state.comment,
         importedVocabularies: this.state.importedVocabularies,
-        document: modifiedDocument,
       })
     );
     newVocabulary.unmappedProperties = this.state.unmappedProperties;
+    this.props.saveDocument(modifiedDocument);
     this.props.save(newVocabulary);
   };
 

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -30,6 +30,7 @@ interface VocabularyEditState {
   comment: string;
   importedVocabularies?: AssetData[];
   unmappedProperties: Map<string, string[]>;
+  documentLabel: string;
 }
 
 export class VocabularyEdit extends React.Component<
@@ -43,6 +44,7 @@ export class VocabularyEdit extends React.Component<
       comment: this.props.vocabulary.comment
         ? this.props.vocabulary.comment
         : "",
+      documentLabel: this.props.vocabulary.document?.label!,
       importedVocabularies: this.props.vocabulary.importedVocabularies,
       unmappedProperties: this.props.vocabulary.unmappedProperties,
     };
@@ -57,11 +59,16 @@ export class VocabularyEdit extends React.Component<
   };
 
   public onSave = () => {
+    const modifiedDocument = Object.assign({}, this.props.vocabulary.document, {
+      label: this.state.documentLabel,
+    });
+
     const newVocabulary = new Vocabulary(
       Object.assign({}, this.props.vocabulary, {
         label: this.state.label,
         comment: this.state.comment,
         importedVocabularies: this.state.importedVocabularies,
+        document: modifiedDocument,
       })
     );
     newVocabulary.unmappedProperties = this.state.unmappedProperties;
@@ -123,7 +130,19 @@ export class VocabularyEdit extends React.Component<
                 />
               </Col>
             </Row>
-
+            <Row>
+              <Col xs={12}>
+                <CustomInput
+                  name="edit-document-label"
+                  label={i18n("vocabulary.document.set.label")}
+                  value={this.state.documentLabel}
+                  onChange={(e) =>
+                    this.onChange({ documentLabel: e.currentTarget.value })
+                  }
+                  hint={i18n("required")}
+                />
+              </Col>
+            </Row>
             <Row>
               <Col xs={12}>
                 <ButtonToolbar className="d-flex justify-content-center mt-4">
@@ -132,7 +151,10 @@ export class VocabularyEdit extends React.Component<
                     onClick={this.onSave}
                     color="success"
                     size="sm"
-                    disabled={this.state.label.trim().length === 0}
+                    disabled={
+                      this.state.label.trim().length === 0 ||
+                      this.state.documentLabel?.trim().length === 0
+                    }
                   >
                     {i18n("save")}
                   </Button>

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -62,7 +62,7 @@ export class VocabularyEdit extends React.Component<
 
   public onSave = () => {
     const modifiedDocument = Object.assign({}, this.props.vocabulary.document, {
-      label: this.state.documentLabel,
+      label: this.state.documentLabel.trim(),
     });
 
     const newVocabulary = new Vocabulary(
@@ -73,7 +73,8 @@ export class VocabularyEdit extends React.Component<
       })
     );
     newVocabulary.unmappedProperties = this.state.unmappedProperties;
-    this.props.saveDocument(modifiedDocument);
+    if (modifiedDocument.label !== this.props.vocabulary.document?.label)
+      this.props.saveDocument(modifiedDocument);
     this.props.save(newVocabulary);
   };
 

--- a/src/component/vocabulary/VocabularySummary.tsx
+++ b/src/component/vocabulary/VocabularySummary.tsx
@@ -9,6 +9,7 @@ import {
   loadResource,
   loadVocabulary,
   removeVocabulary,
+  updateResource,
   updateVocabulary,
   validateVocabulary,
 } from "../../action/AsyncActions";
@@ -41,6 +42,8 @@ import VocabularySnapshotIcon from "./snapshot/VocabularySnapshotIcon";
 import CreateSnapshotDialog from "./CreateSnapshotDialog";
 import classNames from "classnames";
 import SnapshotCreationInfo from "../snapshot/SnapshotCreationInfo";
+import Resource from "../../model/Resource";
+import Document from "../../model/Document";
 
 interface VocabularySummaryProps extends HasI18n, RouteComponentProps<any> {
   vocabulary: Vocabulary;
@@ -53,6 +56,7 @@ interface VocabularySummaryProps extends HasI18n, RouteComponentProps<any> {
   importSkos: (iri: IRI, file: File) => Promise<any>;
   executeTextAnalysisOnAllTerms: (iri: IRI) => void;
   createSnapshot: (iri: IRI) => Promise<any>;
+  updateDocument: (document: Document) => Promise<Resource | null>;
 }
 
 export interface VocabularySummaryState extends EditableComponentState {
@@ -112,6 +116,10 @@ export class VocabularySummary extends EditableComponent<
       this.onCloseEdit();
       this.props.loadVocabulary(VocabularyUtils.create(vocabulary.iri));
     });
+  };
+
+  public onDocumentSave = (document: Document) => {
+    this.props.updateDocument(new Document(document));
   };
 
   public onRemove = () => {
@@ -241,6 +249,7 @@ export class VocabularySummary extends EditableComponent<
         {this.state.edit ? (
           <VocabularyEdit
             save={this.onSave}
+            saveDocument={this.onDocumentSave}
             cancel={this.onCloseEdit}
             vocabulary={vocabulary}
           />
@@ -292,6 +301,8 @@ export default connect(
       executeTextAnalysisOnAllTerms: (iri: IRI) =>
         dispatch(executeTextAnalysisOnAllTerms(iri)),
       createSnapshot: (iri: IRI) => dispatch(createVocabularySnapshot(iri)),
+      updateDocument: (document: Document) =>
+        dispatch(updateResource(document)),
     };
   }
 )(injectIntl(withI18n(VocabularySummary)));

--- a/src/component/vocabulary/VocabularySummary.tsx
+++ b/src/component/vocabulary/VocabularySummary.tsx
@@ -43,7 +43,7 @@ import CreateSnapshotDialog from "./CreateSnapshotDialog";
 import classNames from "classnames";
 import SnapshotCreationInfo from "../snapshot/SnapshotCreationInfo";
 import Resource from "../../model/Resource";
-import Document from "../../model/Document";
+import Document, { DocumentData } from "../../model/Document";
 
 interface VocabularySummaryProps extends HasI18n, RouteComponentProps<any> {
   vocabulary: Vocabulary;
@@ -118,7 +118,7 @@ export class VocabularySummary extends EditableComponent<
     });
   };
 
-  public onDocumentSave = (document: Document) => {
+  public onDocumentSave = (document: DocumentData) => {
     this.props.updateDocument(new Document(document));
   };
 

--- a/src/component/vocabulary/__tests__/VocabularyEdit.test.tsx
+++ b/src/component/vocabulary/__tests__/VocabularyEdit.test.tsx
@@ -6,16 +6,19 @@ import { intlFunctions } from "../../../__tests__/environment/IntlUtil";
 import { shallow } from "enzyme";
 import { UnmappedPropertiesEdit } from "../../genericmetadata/UnmappedPropertiesEdit";
 import VocabularyUtils from "../../../util/VocabularyUtils";
+import Document from "../../../model/Document";
 
 jest.mock("../../misc/MarkdownEditor", () => () => <div>Editor</div>);
 
 describe("VocabularyEdit", () => {
   let onSave: (vocabulary: Vocabulary) => void;
+  let onDocumentSave: (document: Document) => void;
   let onCancel: () => void;
   let vocabulary: Vocabulary;
 
   beforeEach(() => {
     onSave = jest.fn();
+    onDocumentSave = jest.fn();
     onCancel = jest.fn();
     vocabulary = new Vocabulary({
       iri: Generator.generateUri(),
@@ -28,6 +31,7 @@ describe("VocabularyEdit", () => {
       <VocabularyEdit
         vocabulary={vocabulary}
         save={onSave}
+        saveDocument={onDocumentSave}
         cancel={onCancel}
         {...intlFunctions()}
       />
@@ -49,6 +53,7 @@ describe("VocabularyEdit", () => {
       <VocabularyEdit
         vocabulary={vocabulary}
         save={onSave}
+        saveDocument={onDocumentSave}
         cancel={onCancel}
         {...intlFunctions()}
       />
@@ -64,6 +69,7 @@ describe("VocabularyEdit", () => {
       <VocabularyEdit
         vocabulary={vocabulary}
         save={onSave}
+        saveDocument={onDocumentSave}
         cancel={onCancel}
         {...intlFunctions()}
       />
@@ -82,6 +88,7 @@ describe("VocabularyEdit", () => {
       <VocabularyEdit
         vocabulary={vocabulary}
         save={onSave}
+        saveDocument={onDocumentSave}
         cancel={onCancel}
         {...intlFunctions()}
       />
@@ -101,6 +108,7 @@ describe("VocabularyEdit", () => {
       <VocabularyEdit
         vocabulary={vocabulary}
         save={onSave}
+        saveDocument={onDocumentSave}
         cancel={onCancel}
         {...intlFunctions()}
       />

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -284,6 +284,7 @@ const cs = {
     "vocabulary.document.select.title": "Vyberte dokument",
     "vocabulary.document.set": "Změnit dokument",
     "vocabulary.document.remove": "Odpojit dokument",
+    "vocabulary.document.set.label": "Název dokumentu",
     "vocabulary.snapshot.create.label": "Vytvořit revizi",
     "vocabulary.snapshot.create.title":
       "Vytvořit revizi tohoto slovníku a všech dalších slovníků, které jsou s ním (nepřímo) propojeny vztahy mezi pojmy. Revize je kopií veškerého obsahu slovníku a umožňuje tak označit důležité milníky v historii vývoje slovníku.",

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -192,6 +192,7 @@ const cs = {
     "asset.create.hideAdvancedSection": "Skrýt pokročilé možnosti",
     "asset.remove.tooltip": "Odstranit tento záznam",
     "asset.remove.dialog.title": 'Odstranit {type} "{label}"?',
+    "asset.rename.dialog.title": 'Přejmenovat {type} "{label}"',
     "asset.remove.dialog.text": 'Určitě chcete odstranit {type} "{label}"?',
 
     "document.remove.tooltip.disabled":

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -277,6 +277,7 @@ const en = {
     "vocabulary.document.select.title": "Select a document",
     "vocabulary.document.set": "Set document",
     "vocabulary.document.remove": "Detach document",
+    "vocabulary.document.set.label": "Document label",
     "vocabulary.snapshot.create.label": "Create snapshot",
     "vocabulary.snapshot.create.title":
       "Create a snapshot of this vocabulary and all other vocabularies that are (indirectly) connected to it via term relationships. The snapshot is a read-only copy of the whole vocabulary content and can be used to demarcate important milestones in the vocabulary lifecycle.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -182,6 +182,7 @@ const en = {
     "asset.create.hideAdvancedSection": "Hide advanced options",
     "asset.remove.tooltip": "Remove this asset",
     "asset.remove.dialog.title": 'Remove {type} "{label}"?',
+    "asset.rename.dialog.title": 'Rename {type} "{label}"',
     "asset.remove.dialog.text":
       'Are you sure you want to remove {type} "{label}"?',
 

--- a/src/model/File.ts
+++ b/src/model/File.ts
@@ -52,6 +52,9 @@ export default class File extends Resource implements FileData {
       jsonLd.owner.files = Document.replaceCircularReferencesToOwnerWithOwnerId(
         jsonLd.owner.files
       );
+      if (jsonLd.owner.vocabulary) {
+        jsonLd.owner.vocabulary = { iri: jsonLd.owner.vocabulary.iri };
+      }
     }
     return jsonLd;
   }

--- a/src/reducer/TermItReducers.ts
+++ b/src/reducer/TermItReducers.ts
@@ -139,6 +139,7 @@ function vocabulary(
     case ActionType.LOGOUT:
       return EMPTY_VOCABULARY;
     case ActionType.REMOVE_RESOURCE:
+    case ActionType.UPDATE_RESOURCE:
     case ActionType.CREATE_RESOURCE: // intentional fall-through
       // the resource might have been/be related to the vocabulary
       return action.status === AsyncActionStatus.SUCCESS


### PR DESCRIPTION
Added the option to specify the name of the document when creating a vocabulary and also the ability to change it in the edit vocabulary form. Plus added a modal for changing the names of the document's files.

@ledsoft If you don't like the UI, regarding the placement or the behaviour of the components, just let me know and I will fix it right away. 
The backend changes are available in this PR: https://github.com/kbss-cvut/termit/pull/198 