### PR TITLE
Enhancement/369 links in attributes

### DIFF
--- a/src/component/genericmetadata/UnmappedProperties.tsx
+++ b/src/component/genericmetadata/UnmappedProperties.tsx
@@ -33,7 +33,9 @@ const UnmappedProperties: React.FC<UnmappedPropertiesProps> = (
     const items = (
       <ul>
         {sortedItems.map((v: string) => (
-          <li key={Utils.hashCode(v)}>{v}</li>
+          <li key={Utils.hashCode(v)}>
+            {Utils.isLink(v) ? <OutgoingLink label={v} iri={v} /> : v}
+          </li>
         ))}
       </ul>
     );

--- a/src/component/genericmetadata/__tests__/UnmappedProperties.test.tsx
+++ b/src/component/genericmetadata/__tests__/UnmappedProperties.test.tsx
@@ -44,6 +44,7 @@ describe("UnmappedProperties", () => {
     const items = wrapper.find("li");
     expect(items.length).toEqual(1);
     expect(items.exists(OutgoingLink)).toBeTruthy();
+    expect(items.get(0).props.children.props.label).toEqual(v);
   });
 
   it("renders multiple property values sorted lexicographically", () => {

--- a/src/component/genericmetadata/__tests__/UnmappedProperties.test.tsx
+++ b/src/component/genericmetadata/__tests__/UnmappedProperties.test.tsx
@@ -3,6 +3,7 @@ import UnmappedProperties from "../UnmappedProperties";
 import { mountWithIntl } from "../../../__tests__/environment/Environment";
 import { mockUseI18n } from "../../../__tests__/environment/IntlUtil";
 import Utils from "../../../util/Utils";
+import OutgoingLink from "../../misc/OutgoingLink";
 
 jest.mock("../../misc/AssetLabel", () => () => <span>Asset</span>);
 
@@ -19,6 +20,7 @@ describe("UnmappedProperties", () => {
     const items = wrapper.find("li");
     expect(items.length).toEqual(1);
     expect(items.get(0).props.children).toEqual("test");
+    expect(items.exists(OutgoingLink)).toBeFalsy();
   });
 
   it("renders multiple literal values for a property", () => {
@@ -30,6 +32,7 @@ describe("UnmappedProperties", () => {
     expect(items.length).toEqual(2);
     expect(items.get(0).props.children).toEqual("test");
     expect(items.get(1).props.children).toEqual("test2");
+    expect(items.exists(OutgoingLink)).toBeFalsy();
   });
 
   it("handles object value for a property", () => {
@@ -40,7 +43,7 @@ describe("UnmappedProperties", () => {
     );
     const items = wrapper.find("li");
     expect(items.length).toEqual(1);
-    expect(items.get(0).props.children).toEqual(v);
+    expect(items.exists(OutgoingLink)).toBeTruthy();
   });
 
   it("renders multiple property values sorted lexicographically", () => {
@@ -52,6 +55,7 @@ describe("UnmappedProperties", () => {
       <UnmappedProperties properties={properties} />
     );
     const items = wrapper.find("li");
+    expect(items.exists(OutgoingLink)).toBeFalsy();
     expect(items.length).toEqual(values.length);
     for (let i = 0; i < sortedValues.length; i++) {
       expect(items.get(i).props.children).toEqual(sortedValues[i]);


### PR DESCRIPTION
If a value of unmapped property is a valid link, the redirect button appears next to it.
I kept the original output and only added the button, that way the links look the same through the entire application.
@ledsoft The specification did not mention the exact visual style, so if you have any remarks regarding the look, I am ready to change it to your liking.

Closes: #369 