### PR TITLE
Fix/384 missing import terms

### DIFF
--- a/src/component/public/term/Terms.tsx
+++ b/src/component/public/term/Terms.tsx
@@ -107,9 +107,9 @@ export class Terms extends React.Component<GlossaryTermsProps, TermsState> {
       )
       .then((terms) => {
         const matchingVocabularies = this.state.includeImported
-          ? Utils.sanitizeArray(
-              this.props.vocabulary!.allImportedVocabularies
-            ).concat(this.props.vocabulary!.iri)
+          ? Utils.sanitizeArray(this.props.vocabulary!.importedVocabularies)
+              .map((vocabulary) => vocabulary.iri!)
+              .concat(this.props.vocabulary!.iri)
           : [this.props.vocabulary!.iri];
         this.setState({
           disableIncludeImportedToggle: this.props.isDetailView || false,

--- a/src/component/public/term/__tests__/Terms.test.tsx
+++ b/src/component/public/term/__tests__/Terms.test.tsx
@@ -12,6 +12,7 @@ import Generator from "../../../../__tests__/environment/Generator";
 import * as TermTreeSelectHelper from "../../../term/TermTreeSelectHelper";
 import { langString } from "../../../../model/MultilingualString";
 import { TermFetchParams } from "../../../../util/Types";
+import { AssetData } from "../../../../model/Asset";
 
 jest.mock("../../../../util/Routing");
 
@@ -154,7 +155,9 @@ describe("Terms", () => {
         Generator.generateUri(),
         Generator.generateUri(),
       ];
-      vocabulary.allImportedVocabularies = vocabularies;
+      vocabulary.importedVocabularies = vocabularies.map(
+        (vocabulary) => ({ iri: vocabulary } as AssetData)
+      );
       const terms: Term[] = [];
       const matching: Term[] = [];
       for (let i = 0; i < 5; i++) {

--- a/src/component/term/Terms.tsx
+++ b/src/component/term/Terms.tsx
@@ -174,9 +174,9 @@ export class Terms extends React.Component<GlossaryTermsProps, TermsState> {
       )
       .then((terms) => {
         const matchingVocabularies = this.state.includeImported
-          ? Utils.sanitizeArray(
-              this.props.vocabulary!.allImportedVocabularies
-            ).concat(this.props.vocabulary!.iri)
+          ? Utils.sanitizeArray(this.props.vocabulary!.importedVocabularies)
+              .map((vocabulary) => vocabulary.iri!)
+              .concat(this.props.vocabulary!.iri)
           : [this.props.vocabulary!.iri];
         this.setState({
           disableIncludeImportedToggle: this.props.isDetailView || false,

--- a/src/component/term/__tests__/Terms.test.tsx
+++ b/src/component/term/__tests__/Terms.test.tsx
@@ -12,6 +12,7 @@ import Vocabulary from "../../../model/Vocabulary";
 import * as TermTreeSelectHelper from "../TermTreeSelectHelper";
 import { langString } from "../../../model/MultilingualString";
 import { TermFetchParams } from "../../../util/Types";
+import { AssetData } from "../../../model/Asset";
 
 jest.mock("../../../util/Routing");
 
@@ -203,7 +204,9 @@ describe("Terms", () => {
         Generator.generateUri(),
         Generator.generateUri(),
       ];
-      vocabulary.allImportedVocabularies = vocabularies;
+      vocabulary.importedVocabularies = vocabularies.map(
+        (vocabulary) => ({ iri: vocabulary } as AssetData)
+      );
       const terms: Term[] = [];
       const matching: Term[] = [];
       for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
Fixes the missing terms in the term list. It was caused by `processTermsForTreeSelect` which filters out terms that are not from passed array of vocabulary IRIs. However the passed array contained more information than only IRIs (e.g. context). These additional information are not needed for the filter to work.

I am not entirely sure about the test, I rewrote in somewhat not pleasing way. If there is a generator or some custom function that would make it more pleasing to look at, please @ledsoft let me know. But this approach works just fine while having minimal amount of changes applied to the test. 

Resolves: #384 