### PR TITLE
[Enhancement #570] Support remove changes in vocabulary activity diagram

### DIFF
--- a/src/component/vocabulary/TermChangeFrequencyUI.tsx
+++ b/src/component/vocabulary/TermChangeFrequencyUI.tsx
@@ -122,6 +122,9 @@ const TermChangeFrequencyUI: React.FC<TermChangeFrequencyUIProps> = ({
   const termUpdates = aggregatedRecords.filter(
     (r) => r.types.indexOf(VocabularyUtils.UPDATE_EVENT) !== -1
   );
+  const termDeletions = aggregatedRecords.filter(
+    (r) => r.types.indexOf(VocabularyUtils.DELETE_EVENT) !== -1
+  );
 
   const options = {
     chart: {
@@ -170,12 +173,20 @@ const TermChangeFrequencyUI: React.FC<TermChangeFrequencyUIProps> = ({
     {
       name: i18n("vocabulary.termchanges.updates"),
       type: "column",
-      data: termUpdates.map((a) => [a.getDate(), -1 * a.count]),
+      data: termUpdates.map((a) => [a.getDate(), a.count]),
+      color: "var(--info)",
     },
     {
       name: i18n("vocabulary.termchanges.creations"),
       type: "column",
       data: termCreations.map((a) => [a.getDate(), a.count]),
+      color: "var(--primary)",
+    },
+    {
+      name: i18n("vocabulary.termchanges.deletions"),
+      type: "column",
+      data: termDeletions.map((a) => [a.getDate(), a.count]),
+      color: "var(--danger)",
     },
   ];
   return (

--- a/src/component/vocabulary/TermChangeFrequencyUI.tsx
+++ b/src/component/vocabulary/TermChangeFrequencyUI.tsx
@@ -171,16 +171,16 @@ const TermChangeFrequencyUI: React.FC<TermChangeFrequencyUIProps> = ({
 
   const series = [
     {
-      name: i18n("vocabulary.termchanges.updates"),
-      type: "column",
-      data: termUpdates.map((a) => [a.getDate(), a.count]),
-      color: "var(--info)",
-    },
-    {
       name: i18n("vocabulary.termchanges.creations"),
       type: "column",
       data: termCreations.map((a) => [a.getDate(), a.count]),
       color: "var(--primary)",
+    },
+    {
+      name: i18n("vocabulary.termchanges.updates"),
+      type: "column",
+      data: termUpdates.map((a) => [a.getDate(), a.count]),
+      color: "var(--info)",
     },
     {
       name: i18n("vocabulary.termchanges.deletions"),

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -358,6 +358,7 @@ const cs = {
       "Textová analýza definic pojmů ve všech slovnících spuštěna.",
     "vocabulary.termchanges.creations": "Vytvořené pojmy",
     "vocabulary.termchanges.updates": "Aktualizované pojmy",
+    "vocabulary.termchanges.deletions": "Smazané pojmy",
     "vocabulary.termchanges.termcount": "Počet změněných pojmů",
     "vocabulary.termchanges.loading": "Načítám změny ...",
     "vocabulary.termchanges.empty":

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -351,6 +351,7 @@ const en = {
       "Text analysis of terms' definitions in all vocabularies invoked.",
     "vocabulary.termchanges.creations": "Created terms",
     "vocabulary.termchanges.updates": "Updated terms",
+    "vocabulary.termchanges.deletions": "Deleted terms",
     "vocabulary.termchanges.termcount": "Changed term count",
     "vocabulary.termchanges.loading": "Loading changes ...",
     "vocabulary.termchanges.empty": "No creations/updates of terms found.",


### PR DESCRIPTION
resolves #570 

- Changed colors in the chart to to primary, info and danger color from theme
- All bars are showed above zero
- Added series for deleted terms

![{AC85B2AE-E549-4867-A381-32834C2B239B}](https://github.com/user-attachments/assets/61012f37-f0cd-46d5-baf7-62f04f9fce28)

