### PR TITLE
[Enhancement #585] WebSocket connect improvements

### DIFF
--- a/src/WebSocketApp.tsx
+++ b/src/WebSocketApp.tsx
@@ -96,7 +96,7 @@ export const WebSocketWrapper: React.FC<{
 
   useEffect(() => {
     const callback = () => {
-      const token = SecurityUtils.loadToken();
+      const token = SecurityUtils.loadToken() || "";
       // using length prevents from aborting websocket due to token refresh
       // but will abort it when token is cleared or new one is set
       if (token.length !== securityToken.length) {
@@ -119,6 +119,10 @@ export const WebSocketWrapper: React.FC<{
       onUnhandledReceipt={(receipt) =>
         console.warn("Unhandled STOMP receipt", receipt)
       }
+      onStompError={(frame) => {
+        console.error("WebSocket STOMP error", frame);
+        setSecurityToken("");
+      }}
     >
       {loadDispatchers && registerDispatchers()}
       {children}

--- a/src/WebSocketApp.tsx
+++ b/src/WebSocketApp.tsx
@@ -93,23 +93,28 @@ export const WebSocketWrapper: React.FC<{
   loadDispatchers = true,
 }) => {
   const [securityToken, setSecurityToken] = useState<string>("");
+  const [isTokenInvalid, setIsTokenInvalid] = useState<boolean>(false);
 
   useEffect(() => {
     const callback = () => {
       const token = SecurityUtils.loadToken() || "";
       // using length prevents from aborting websocket due to token refresh
       // but will abort it when token is cleared or new one is set
-      if (token.length !== securityToken.length) {
+      if (
+        token.length !== securityToken.length ||
+        (isTokenInvalid && token !== securityToken)
+      ) {
         setSecurityToken(token);
+        setIsTokenInvalid(false);
       }
     };
     callback();
     return BrowserStorage.onTokenChange(callback);
-  }, [securityToken]);
+  }, [securityToken, isTokenInvalid]);
 
   return (
     <Provider
-      enabled={securityToken.trim() !== ""}
+      enabled={securityToken.trim() !== "" && !isTokenInvalid}
       url={Constants.WEBSOCKET_URL}
       connectHeaders={{
         Authorization: securityToken,
@@ -121,7 +126,7 @@ export const WebSocketWrapper: React.FC<{
       }
       onStompError={(frame) => {
         console.error("WebSocket STOMP error", frame);
-        setSecurityToken("");
+        setIsTokenInvalid(true);
       }}
     >
       {loadDispatchers && registerDispatchers()}


### PR DESCRIPTION
When the WebSocket receives an error, it will mark the current JWT token as invalid and not attempt another connection until the token is refreshed.

Resolves #585 