### PR TITLE
[Enhancement #521] Allow setting primary language on vocabulary level

### DIFF
--- a/src/component/annotator/Annotator.tsx
+++ b/src/component/annotator/Annotator.tsx
@@ -688,6 +688,9 @@ export class Annotator extends React.Component<AnnotatorProps, AnnotatorState> {
               annotationElement={
                 this.state.existingTermDefinitionAnnotationElement
               }
+              language={
+                this.props.annotationLanguage || this.props.file.language
+              }
               onCancel={this.onCloseTermDefinitionDialog}
               onSave={this.onSaveTermDefinition}
             />

--- a/src/component/annotator/Annotator.tsx
+++ b/src/component/annotator/Annotator.tsx
@@ -671,6 +671,9 @@ export class Annotator extends React.Component<AnnotatorProps, AnnotatorState> {
               onMinimize={this.onMinimizeTermCreation}
               onTermCreated={this.assignNewTerm}
               vocabularyIri={this.props.vocabularyIri}
+              fileLanguage={
+                this.props.annotationLanguage || this.props.file.language
+              }
             />
             <SelectionPurposeDialog
               target={this.generateVirtualPopperAnchor()}

--- a/src/component/annotator/CreateTermFromAnnotation.tsx
+++ b/src/component/annotator/CreateTermFromAnnotation.tsx
@@ -53,7 +53,7 @@ function insertEmptyTranslationIfNotExists(
   str: MultilingualString,
   language: string
 ) {
-  if (!hasNonBlankValue(str, language)) {
+  if (language && !hasNonBlankValue(str, language)) {
     str[language] = "";
   }
 }

--- a/src/component/annotator/CreateTermFromAnnotation.tsx
+++ b/src/component/annotator/CreateTermFromAnnotation.tsx
@@ -4,6 +4,8 @@ import Term, { TermData } from "../../model/Term";
 import {
   Button,
   ButtonToolbar,
+  Card,
+  CardBody,
   Col,
   Modal,
   ModalBody,
@@ -17,9 +19,17 @@ import { ThunkDispatch } from "../../util/Types";
 import { createTerm } from "../../action/AsyncTermActions";
 import { IRI } from "../../util/VocabularyUtils";
 import AssetFactory from "../../util/AssetFactory";
-import { langString } from "../../model/MultilingualString";
+import {
+  hasNonBlankValue,
+  langString,
+  MultilingualString,
+} from "../../model/MultilingualString";
 import TermItState from "../../model/TermItState";
 import { isTermValid, LabelExists } from "../term/TermValidationUtils";
+import EditLanguageSelector from "../multilingual/EditLanguageSelector";
+import Message from "../../model/Message";
+import MessageType from "../../model/MessageType";
+import { publishMessage as publishMessageAction } from "../../action/SyncActions";
 
 interface CreateTermFromAnnotationProps extends HasI18n {
   show: boolean;
@@ -27,13 +37,25 @@ interface CreateTermFromAnnotationProps extends HasI18n {
   onMinimize: () => void; // Minimize will be used to allow the user to select definition for a term being created
   onTermCreated: (term: Term) => void;
   vocabularyIri: IRI;
-  language: string;
+  fileLanguage?: string;
+  vocabularyPrimaryLanguage: string;
 
   createTerm: (term: Term, vocabularyIri: IRI) => Promise<any>;
+  publishMessage: (message: Message) => void;
 }
 
 interface CreateTermFromAnnotationState extends TermData {
   labelExists: LabelExists;
+  selectedLanguage: string;
+}
+
+function insertEmptyTranslationIfNotExists(
+  str: MultilingualString,
+  language: string
+) {
+  if (!hasNonBlankValue(str, language)) {
+    str[language] = "";
+  }
 }
 
 export class CreateTermFromAnnotation extends React.Component<
@@ -42,10 +64,17 @@ export class CreateTermFromAnnotation extends React.Component<
 > {
   constructor(props: CreateTermFromAnnotationProps) {
     super(props);
-    this.state = Object.assign(
-      {},
-      AssetFactory.createEmptyTermData(props.language),
-      { labelExists: {} }
+    const language =
+      this.props.fileLanguage || this.props.vocabularyPrimaryLanguage;
+
+    this.state = Object.assign({}, AssetFactory.createEmptyTermData(language), {
+      labelExists: {},
+      selectedLanguage: language,
+    });
+
+    insertEmptyTranslationIfNotExists(
+      this.state.label,
+      this.props.vocabularyPrimaryLanguage
     );
   }
 
@@ -53,8 +82,13 @@ export class CreateTermFromAnnotation extends React.Component<
    * Part of public imperative API allowing to set label so that the whole term does not have to be kept in parent
    * component state.
    */
-  public setLabel(label: string) {
-    this.setState({ label: langString(label.trim(), this.props.language) });
+  public setLabel(newLabel: string) {
+    const label = langString(newLabel.trim(), this.state.selectedLanguage);
+    insertEmptyTranslationIfNotExists(
+      label,
+      this.props.vocabularyPrimaryLanguage
+    );
+    this.setState({ label });
   }
 
   /**
@@ -63,7 +97,7 @@ export class CreateTermFromAnnotation extends React.Component<
    */
   public setDefinition(definition: string) {
     this.setState({
-      definition: langString(definition.trim(), this.props.language),
+      definition: langString(definition.trim(), this.state.selectedLanguage),
     });
   }
 
@@ -80,13 +114,44 @@ export class CreateTermFromAnnotation extends React.Component<
   };
 
   public onCancel = () => {
-    this.setState(AssetFactory.createEmptyTermData(this.props.language));
+    const stateChange = AssetFactory.createEmptyTermData(
+      this.props.fileLanguage || this.props.vocabularyPrimaryLanguage
+    );
+    insertEmptyTranslationIfNotExists(
+      stateChange.label,
+      this.props.vocabularyPrimaryLanguage
+    );
+    this.setState(stateChange);
     this.props.onClose();
+  };
+
+  private setLanguage = (language: string) => {
+    this.setState({ selectedLanguage: language });
+  };
+
+  private onRemoveTranslation = (language: string) => {
+    if (language === this.props.vocabularyPrimaryLanguage) {
+      this.props.publishMessage(
+        new Message(
+          {
+            messageId:
+              "asset.modify.error.cannotRemoveVocabularyPrimaryLanguage",
+          },
+          MessageType.ERROR
+        )
+      );
+      this.setLanguage(this.state.selectedLanguage);
+      return;
+    }
   };
 
   public render() {
     const i18n = this.props.i18n;
-    const invalid = !isTermValid(this.state, this.state.labelExists);
+    const invalid = !isTermValid(
+      this.state,
+      this.state.labelExists,
+      this.props.vocabularyPrimaryLanguage
+    );
     return (
       <Modal
         id="annotator-create-term"
@@ -96,40 +161,50 @@ export class CreateTermFromAnnotation extends React.Component<
       >
         <ModalHeader>{i18n("glossary.form.header")}</ModalHeader>
         <ModalBody>
-          <TermMetadataCreateForm
-            onChange={this.onChange}
-            termData={this.state}
-            language={this.props.language}
-            definitionSelector={this.props.onMinimize}
-            vocabularyIri={
-              this.props.vocabularyIri.namespace +
-              this.props.vocabularyIri.fragment
-            }
-            labelExist={this.state.labelExists}
+          <EditLanguageSelector
+            language={this.state.selectedLanguage}
+            existingLanguages={Term.getLanguages(this.state)}
+            onSelect={this.setLanguage}
+            onRemove={this.onRemoveTranslation}
           />
-          <Row>
-            <Col xs={12}>
-              <ButtonToolbar className="d-flex justify-content-center mt-4">
-                <Button
-                  id="create-term-submit"
-                  color="success"
-                  onClick={this.onSave}
-                  disabled={invalid}
-                  size="sm"
-                >
-                  {i18n("glossary.form.button.submit")}
-                </Button>
-                <Button
-                  id="create-term-cancel"
-                  color="outline-dark"
-                  size="sm"
-                  onClick={this.onCancel}
-                >
-                  {i18n("glossary.form.button.cancel")}
-                </Button>
-              </ButtonToolbar>
-            </Col>
-          </Row>
+          <Card id="create-term">
+            <CardBody>
+              <TermMetadataCreateForm
+                onChange={this.onChange}
+                termData={this.state}
+                language={this.state.selectedLanguage}
+                definitionSelector={this.props.onMinimize}
+                vocabularyIri={
+                  this.props.vocabularyIri.namespace +
+                  this.props.vocabularyIri.fragment
+                }
+                labelExist={this.state.labelExists}
+              />
+              <Row>
+                <Col xs={12}>
+                  <ButtonToolbar className="d-flex justify-content-center mt-4">
+                    <Button
+                      id="create-term-submit"
+                      color="success"
+                      onClick={this.onSave}
+                      disabled={invalid}
+                      size="sm"
+                    >
+                      {i18n("glossary.form.button.submit")}
+                    </Button>
+                    <Button
+                      id="create-term-cancel"
+                      color="outline-dark"
+                      size="sm"
+                      onClick={this.onCancel}
+                    >
+                      {i18n("glossary.form.button.cancel")}
+                    </Button>
+                  </ButtonToolbar>
+                </Col>
+              </Row>
+            </CardBody>
+          </Card>
         </ModalBody>
       </Modal>
     );
@@ -137,11 +212,16 @@ export class CreateTermFromAnnotation extends React.Component<
 }
 
 export default connect(
-  (state: TermItState) => ({ language: state.configuration.language }),
+  (state: TermItState) => ({
+    vocabularyPrimaryLanguage:
+      state.vocabulary.primaryLanguage || state.configuration.language,
+  }),
   (dispatch: ThunkDispatch) => {
     return {
       createTerm: (term: Term, vocabularyIri: IRI) =>
         dispatch(createTerm(term, vocabularyIri)),
+      publishMessage: (message: Message) =>
+        dispatch(publishMessageAction(message)),
     };
   },
   undefined,

--- a/src/component/annotator/TermDefinitionEdit.tsx
+++ b/src/component/annotator/TermDefinitionEdit.tsx
@@ -24,6 +24,7 @@ import { useI18n } from "../hook/useI18n";
 interface TermDefinitionEditProps {
   term?: Term;
   annotationElement?: Element;
+  language?: string;
   onSave: (update: Term) => void;
   onCancel: () => void;
 }
@@ -37,9 +38,11 @@ export const TermDefinitionEdit: React.FC<TermDefinitionEditProps> = (
 ) => {
   const { term, annotationElement, onSave, onCancel } = props;
   const { i18n, formatMessage, locale } = useI18n();
-  const language = useSelector(
-    (state: TermItState) => state.configuration.language
+  const fallbackLanguage = useSelector(
+    (state: TermItState) =>
+      state.vocabulary.primaryLanguage || state.configuration.language
   );
+  const language = props.language || fallbackLanguage;
   const onChange = (change: Partial<TermData>) =>
     setData(new Term(Object.assign({}, data, change)));
   const [data, setData] = React.useState<Term>();

--- a/src/component/annotator/TextAnalysisInvocationButton.tsx
+++ b/src/component/annotator/TextAnalysisInvocationButton.tsx
@@ -1,118 +1,75 @@
-import * as React from "react";
-import { injectIntl } from "react-intl";
-import withI18n, { HasI18n } from "../hoc/withI18n";
+import { useCallback, useState } from "react";
 import { GoClippy } from "react-icons/go";
 import { Button } from "reactstrap";
-import { connect } from "react-redux";
+import { useDispatch } from "react-redux";
 import { ThunkDispatch } from "../../util/Types";
-import { executeFileTextAnalysis } from "../../action/AsyncActions";
 import ResourceSelectVocabulary from "../resource/ResourceSelectVocabulary";
 import Vocabulary from "../../model/Vocabulary";
 import { IRI, IRIImpl } from "../../util/VocabularyUtils";
-import { IMessage, withSubscription } from "react-stomp-hooks";
+import { IMessage, useSubscription } from "react-stomp-hooks";
 import Constants from "../../util/Constants";
+import { useI18n } from "../hook/useI18n";
+import { executeFileTextAnalysis } from "../../action/AsyncActions";
 import { publishMessage, publishNotification } from "../../action/SyncActions";
-import NotificationType from "../../model/NotificationType";
 import Message, { createFormattedMessage } from "../../model/Message";
 import MessageType from "../../model/MessageType";
+import NotificationType from "../../model/NotificationType";
 
-interface TextAnalysisInvocationButtonProps extends HasI18n {
+interface TextAnalysisInvocationButtonProps {
   id?: string;
   fileIri: IRI;
   defaultVocabularyIri?: string;
-  executeTextAnalysis: (fileIri: IRI, vocabularyIri: string) => Promise<any>;
-  notifyAnalysisFinish: () => void;
-  notifyAnalysisFailed: (message: string) => void;
   className?: string;
 }
 
-interface TextAnalysisInvocationButtonState {
-  showVocabularySelector: boolean;
+function stripQuotes(str: string): string {
+  return str.replace(/^"(.*)"$/, "$1");
 }
 
-export class TextAnalysisInvocationButton extends React.Component<
-  TextAnalysisInvocationButtonProps,
-  TextAnalysisInvocationButtonState
-> {
-  constructor(props: TextAnalysisInvocationButtonProps) {
-    super(props);
-    this.state = { showVocabularySelector: false };
-  }
+export default function TextAnalysisInvocationButton(
+  props: TextAnalysisInvocationButtonProps
+) {
+  const { id, fileIri, defaultVocabularyIri, className } = props;
+  const [showVocabularySelector, setShowVocabularySelector] = useState(false);
+  const { i18n } = useI18n();
+  const dispatch: ThunkDispatch = useDispatch();
 
-  public onClick = () => {
-    this.setState({ showVocabularySelector: true });
-  };
+  const openVocabularySelector = useCallback(
+    () => setShowVocabularySelector(true),
+    [setShowVocabularySelector]
+  );
 
-  private invokeTextAnalysis(fileIri: IRI, vocabularyIri: string) {
-    this.props.executeTextAnalysis(fileIri, vocabularyIri);
-  }
+  const closeVocabularySelector = useCallback(
+    () => setShowVocabularySelector(false),
+    [setShowVocabularySelector]
+  );
 
-  public onVocabularySelect = (vocabulary: Vocabulary | null) => {
-    this.closeVocabularySelect();
-    if (!vocabulary) {
-      return;
-    }
-    this.invokeTextAnalysis(this.props.fileIri, vocabulary.iri);
-  };
-
-  private closeVocabularySelect = () => {
-    this.setState({ showVocabularySelector: false });
-  };
-
-  public onMessage(message: IMessage) {
-    if (!message?.body) {
-      return;
-    }
-    if (
-      message.headers.destination ===
-        Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FINISHED_FILE &&
-      message.body.substring(1, message.body.length - 1) ===
-        IRIImpl.toString(this.props.fileIri)
-    ) {
-      this.props.notifyAnalysisFinish();
-    }
-    if (
-      message.headers.destination ===
-      Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FAILED
-    ) {
-      // strips double quotes
-      const errorMessage = message.body.replace(/^"(.*)"$/, "$1");
-      this.props.notifyAnalysisFailed(errorMessage);
-    }
-  }
-
-  public render() {
-    const i18n = this.props.i18n;
-    return (
-      <>
-        <ResourceSelectVocabulary
-          show={this.state.showVocabularySelector}
-          defaultVocabularyIri={this.props.defaultVocabularyIri}
-          onCancel={this.closeVocabularySelect}
-          onSubmit={this.onVocabularySelect}
-          title={i18n("file.metadata.startTextAnalysis.vocabularySelect.title")}
-        />
-        <Button
-          id={this.props.id}
-          size="sm"
-          color="primary"
-          className={this.props.className}
-          title={i18n("file.metadata.startTextAnalysis")}
-          onClick={this.onClick}
-        >
-          <GoClippy className="mr-1" />
-          {i18n("file.metadata.startTextAnalysis.text")}
-        </Button>
-      </>
-    );
-  }
-}
-
-export default connect(undefined, (dispatch: ThunkDispatch) => {
-  return {
-    executeTextAnalysis: (fileIri: IRI, vocabularyIri: string) =>
+  const executeTextAnalysis = useCallback(
+    (fileIri: IRI, vocabularyIri: string) =>
       dispatch(executeFileTextAnalysis(fileIri, vocabularyIri)),
-    notifyAnalysisFailed: (message: string) => {
+    [dispatch]
+  );
+
+  const notifyAnalysisFinish = useCallback(() => {
+    dispatch(
+      publishMessage(
+        new Message(
+          {
+            messageId: "file.text-analysis.finished.message",
+          },
+          MessageType.SUCCESS
+        )
+      )
+    );
+    dispatch(
+      publishNotification({
+        source: { type: NotificationType.TEXT_ANALYSIS_FINISHED },
+      })
+    );
+  }, [dispatch]);
+
+  const notifyAnalysisFailed = useCallback(
+    (message: string) =>
       dispatch(
         publishMessage(
           createFormattedMessage(
@@ -121,33 +78,69 @@ export default connect(undefined, (dispatch: ThunkDispatch) => {
             MessageType.ERROR
           )
         )
-      );
+      ),
+    [dispatch]
+  );
+
+  const onVocabularySelect = useCallback(
+    (vocabulary: Vocabulary | null) => {
+      setShowVocabularySelector(false);
+      if (!vocabulary) {
+        return;
+      }
+      executeTextAnalysis(fileIri, vocabulary.iri);
     },
-    notifyAnalysisFinish: () => {
-      dispatch(
-        publishMessage(
-          new Message(
-            {
-              messageId: "file.text-analysis.finished.message",
-            },
-            MessageType.SUCCESS
-          )
-        )
-      );
-      dispatch(
-        publishNotification({
-          source: { type: NotificationType.TEXT_ANALYSIS_FINISHED },
-        })
-      );
+    [setShowVocabularySelector, executeTextAnalysis, fileIri]
+  );
+
+  const onWsMessage = useCallback(
+    (message: IMessage) => {
+      if (
+        message.headers.destination ===
+          Constants.WEBSOCKET_ENDPOINT
+            .VOCABULARIES_TEXT_ANALYSIS_FINISHED_FILE &&
+        stripQuotes(message.body) === IRIImpl.toString(fileIri)
+      ) {
+        notifyAnalysisFinish();
+      }
+      if (
+        message.headers.destination ===
+        Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FAILED
+      ) {
+        notifyAnalysisFailed(stripQuotes(message.body));
+      }
     },
-  };
-})(
-  injectIntl(
-    withI18n(
-      withSubscription(TextAnalysisInvocationButton, [
-        Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FINISHED_FILE,
-        Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FAILED,
-      ])
-    )
-  )
-);
+    [fileIri, notifyAnalysisFinish, notifyAnalysisFailed]
+  );
+
+  useSubscription(
+    [
+      Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FINISHED_FILE,
+      Constants.WEBSOCKET_ENDPOINT.VOCABULARIES_TEXT_ANALYSIS_FAILED,
+    ],
+    onWsMessage
+  );
+
+  return (
+    <>
+      <ResourceSelectVocabulary
+        show={showVocabularySelector}
+        defaultVocabularyIri={defaultVocabularyIri}
+        onCancel={closeVocabularySelector}
+        onSubmit={onVocabularySelect}
+        title={i18n("file.metadata.startTextAnalysis.vocabularySelect.title")}
+      />
+      <Button
+        id={id}
+        size="sm"
+        color="primary"
+        className={className}
+        title={i18n("file.metadata.startTextAnalysis")}
+        onClick={openVocabularySelector}
+      >
+        <GoClippy className="mr-1" />
+        {i18n("file.metadata.startTextAnalysis.text")}
+      </Button>
+    </>
+  );
+}

--- a/src/component/annotator/__tests__/TextAnalysisInvocationButton.test.tsx
+++ b/src/component/annotator/__tests__/TextAnalysisInvocationButton.test.tsx
@@ -1,90 +1,99 @@
 import File from "../../../model/File";
-import VocabularyUtils, { IRI } from "../../../util/VocabularyUtils";
+import VocabularyUtils from "../../../util/VocabularyUtils";
 import Generator from "../../../__tests__/environment/Generator";
-import { shallow } from "enzyme";
-import { TextAnalysisInvocationButton } from "../TextAnalysisInvocationButton";
-import { intlFunctions } from "../../../__tests__/environment/IntlUtil";
+import TextAnalysisInvocationButton from "../TextAnalysisInvocationButton";
 import ResourceSelectVocabulary from "../../resource/ResourceSelectVocabulary";
 import Vocabulary from "../../../model/Vocabulary";
-import { webSocketProviderWrappingComponentOptions } from "../../../__tests__/environment/Environment";
+import * as Redux from "react-redux";
+import { mockUseI18n } from "../../../__tests__/environment/IntlUtil";
+import * as AsyncActions from "../../../action/AsyncActions";
+import {
+  mountWithIntl,
+  webSocketProviderWrappingComponentOptions,
+} from "../../../__tests__/environment/Environment";
+import { act } from "react-dom/test-utils";
+
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useDispatch: jest.fn(),
+}));
+
+const mount = (
+  el: React.ReactElement<any, string | React.JSXElementConstructor<any>>
+) => mountWithIntl(el, webSocketProviderWrappingComponentOptions);
 
 describe("TextAnalysisInvocationButton", () => {
   const namespace = "http://onto.fel.cvut.cz/ontologies/termit/resources/";
   const fileName = "test.html";
 
   let file: File;
-
-  let executeTextAnalysis: (
-    fileIri: IRI,
-    vocabularyIri?: string
-  ) => Promise<any>;
-  let notifyAnalysisFinish: () => void;
   let vocabulary: Vocabulary;
 
   beforeEach(() => {
+    jest.resetAllMocks();
     file = new File({
       iri: namespace + fileName,
       label: fileName,
       types: [VocabularyUtils.FILE, VocabularyUtils.RESOURCE],
     });
-    executeTextAnalysis = jest.fn().mockImplementation(() => Promise.resolve());
-    notifyAnalysisFinish = jest.fn();
     vocabulary = Generator.generateVocabulary();
+    mockUseI18n();
+    const fakeDispatch = jest.fn().mockResolvedValue({});
+    (Redux.useDispatch as jest.Mock).mockReturnValue(fakeDispatch);
   });
 
   it("runs text analysis immediately when defaultVocabulary was specified.", () => {
     const vocabularyIri = Generator.generateUri();
     vocabulary.iri = vocabularyIri;
     const fileIri = VocabularyUtils.create(file.iri);
-    const wrapper = shallow<TextAnalysisInvocationButton>(
+
+    jest.spyOn(AsyncActions, "executeFileTextAnalysis");
+
+    const wrapper = mount(
       <TextAnalysisInvocationButton
         fileIri={fileIri}
-        executeTextAnalysis={executeTextAnalysis}
-        notifyAnalysisFinish={notifyAnalysisFinish}
         defaultVocabularyIri={vocabularyIri}
-        {...intlFunctions()}
       />
     );
-    wrapper.instance().onVocabularySelect(vocabulary);
-    expect(executeTextAnalysis).toHaveBeenCalledWith(fileIri, vocabularyIri);
+    wrapper.find(ResourceSelectVocabulary).props().onSubmit(vocabulary);
+    expect(AsyncActions.executeFileTextAnalysis).toHaveBeenCalledWith(
+      fileIri,
+      vocabularyIri
+    );
   });
 
   it("shows vocabulary selector when no default vocabulary was specified", () => {
     const fileIri = VocabularyUtils.create(Generator.generateUri());
-    const wrapper = shallow<TextAnalysisInvocationButton>(
-      <TextAnalysisInvocationButton
-        fileIri={fileIri}
-        executeTextAnalysis={executeTextAnalysis}
-        notifyAnalysisFinish={notifyAnalysisFinish}
-        {...intlFunctions()}
-      />,
-      webSocketProviderWrappingComponentOptions
-    );
-    wrapper.instance().onClick();
+    jest.spyOn(AsyncActions, "executeFileTextAnalysis");
+    const wrapper = mount(<TextAnalysisInvocationButton fileIri={fileIri} />);
+    wrapper.simulate("click");
     wrapper.update();
-    expect(wrapper.instance().state.showVocabularySelector).toBeTruthy();
     expect(wrapper.exists(ResourceSelectVocabulary));
-    expect(executeTextAnalysis).not.toHaveBeenCalled();
+    expect(wrapper.find(ResourceSelectVocabulary).props().show).toBeTruthy();
+    expect(AsyncActions.executeFileTextAnalysis).not.toHaveBeenCalled();
   });
 
   it("invokes text analysis with selected Vocabulary when Vocabulary selector is submitted", () => {
-    const wrapper = shallow<TextAnalysisInvocationButton>(
+    jest.spyOn(AsyncActions, "executeFileTextAnalysis");
+    const wrapper = mount(
       <TextAnalysisInvocationButton
         fileIri={VocabularyUtils.create(file.iri)}
-        executeTextAnalysis={executeTextAnalysis}
-        notifyAnalysisFinish={notifyAnalysisFinish}
-        {...intlFunctions()}
       />
     );
-    wrapper.instance().onClick();
+    wrapper.simulate("click");
     wrapper.update();
-    expect(wrapper.instance().state.showVocabularySelector).toBeTruthy();
-    wrapper.instance().onVocabularySelect(vocabulary);
-    expect(executeTextAnalysis).toHaveBeenLastCalledWith(
+
+    expect(wrapper.find(ResourceSelectVocabulary).props().show).toBeTruthy();
+
+    act(() => {
+      wrapper.find(ResourceSelectVocabulary).props().onSubmit(vocabulary);
+    });
+
+    expect(AsyncActions.executeFileTextAnalysis).toHaveBeenLastCalledWith(
       VocabularyUtils.create(file.iri),
       vocabulary.iri
     );
     wrapper.update();
-    expect(wrapper.instance().state.showVocabularySelector).toBeFalsy();
+    expect(wrapper.find(ResourceSelectVocabulary).props().show).toBeFalsy();
   });
 });

--- a/src/component/term/CreateTerm.tsx
+++ b/src/component/term/CreateTerm.tsx
@@ -90,7 +90,8 @@ export class CreateTerm extends React.Component<CreateTermProps> {
 export default connect(
   (state: TermItState) => {
     return {
-      language: state.configuration.language,
+      language:
+        state.vocabulary.primaryLanguage || state.configuration.language,
       vocabulary: state.vocabulary,
     };
   },

--- a/src/component/term/TermDetail.tsx
+++ b/src/component/term/TermDetail.tsx
@@ -92,6 +92,7 @@ export interface TermDetailState extends EditableComponentState {
 
 export function resolveInitialLanguage(props: CommonTermDetailProps) {
   const { term, configuredLanguage, locale } = props;
+  if (props.vocabulary.primaryLanguage) return props.vocabulary.primaryLanguage;
   const supported = term ? Term.getLanguages(term) : [];
   const langLocale = getShortLocale(locale);
   return supported.indexOf(langLocale) !== -1 ? langLocale : configuredLanguage;

--- a/src/component/term/TermDetail.tsx
+++ b/src/component/term/TermDetail.tsx
@@ -92,7 +92,9 @@ export interface TermDetailState extends EditableComponentState {
 
 export function resolveInitialLanguage(props: CommonTermDetailProps) {
   const { term, configuredLanguage, locale } = props;
-  if (props.vocabulary.primaryLanguage) return props.vocabulary.primaryLanguage;
+  if (props.vocabulary.primaryLanguage) {
+    return props.vocabulary.primaryLanguage;
+  }
   const supported = term ? Term.getLanguages(term) : [];
   const langLocale = getShortLocale(locale);
   return supported.indexOf(langLocale) !== -1 ? langLocale : configuredLanguage;

--- a/src/component/term/TermMetadataCreate.tsx
+++ b/src/component/term/TermMetadataCreate.tsx
@@ -63,16 +63,16 @@ export class TermMetadataCreate extends React.Component<
     });
   };
 
+  private isInvalid = (): boolean => {
+    return !isTermValid(
+      this.state,
+      this.state.labelExist,
+      this.props.vocabularyPrimaryLanguage
+    );
+  };
+
   private onSave = () => {
-    if (this.isPrimaryLabelMissing()) {
-      this.props.publishMessage(
-        new Message(
-          {
-            messageId: "vocabulary.modify.error.missingPrimaryLabel",
-          },
-          MessageType.ERROR
-        )
-      );
+    if (this.isInvalid()) {
       return;
     }
     const t = new Term(this.state);
@@ -81,14 +81,10 @@ export class TermMetadataCreate extends React.Component<
     this.props.onCreate(t, false);
   };
 
-  private isPrimaryLabelMissing = () => {
-    return (
-      this.state.label[this.props.vocabularyPrimaryLanguage] == null ||
-      this.state.label[this.props.vocabularyPrimaryLanguage].trim() === ""
-    );
-  };
-
   private onSaveAndGoToNewTerm = () => {
+    if (this.isInvalid()) {
+      return;
+    }
     const t = new Term(this.state);
     // @ts-ignore
     delete t.language;
@@ -125,7 +121,7 @@ export class TermMetadataCreate extends React.Component<
 
   public render() {
     const i18n = this.props.i18n;
-    const invalid = !isTermValid(this.state, this.state.labelExist);
+    const invalid = this.isInvalid();
 
     return (
       <>

--- a/src/component/term/TermMetadataCreate.tsx
+++ b/src/component/term/TermMetadataCreate.tsx
@@ -104,7 +104,7 @@ export class TermMetadataCreate extends React.Component<
   };
 
   public onRemoveTranslation = (language: string) => {
-    if (language == this.props.vocabularyPrimaryLanguage) {
+    if (language === this.props.vocabularyPrimaryLanguage) {
       this.props.publishMessage(
         new Message(
           {

--- a/src/component/term/TermMetadataCreate.tsx
+++ b/src/component/term/TermMetadataCreate.tsx
@@ -149,5 +149,5 @@ export class TermMetadataCreate extends React.Component<
 }
 
 export default connect((state: TermItState) => ({
-  language: state.configuration.language,
+  language: state.vocabulary.primaryLanguage || state.configuration.language,
 }))(withRouter(injectIntl(withI18n(TermMetadataCreate))));

--- a/src/component/term/TermMetadataEdit.tsx
+++ b/src/component/term/TermMetadataEdit.tsx
@@ -223,16 +223,16 @@ export class TermMetadataEdit extends React.Component<
     this.setState({ unmappedProperties: update });
   };
 
+  private isInvalid = (): boolean => {
+    return !isTermValid(
+      this.state,
+      this.state.labelExist,
+      this.props.vocabularyPrimaryLanguage
+    );
+  };
+
   public onSave = () => {
-    if (this.isPrimaryLabelMissing()) {
-      this.props.publishMessage(
-        new Message(
-          {
-            messageId: "vocabulary.modify.error.missingPrimaryLabel",
-          },
-          MessageType.ERROR
-        )
-      );
+    if (this.isInvalid()) {
       return;
     }
     const { labelExist, unmappedProperties, definitionRelated, ...data } =
@@ -240,13 +240,6 @@ export class TermMetadataEdit extends React.Component<
     const t = new Term(data);
     t.unmappedProperties = this.state.unmappedProperties;
     this.props.save(t, definitionRelated);
-  };
-
-  private isPrimaryLabelMissing = () => {
-    return (
-      this.state.label[this.props.vocabularyPrimaryLanguage] == null ||
-      this.state.label[this.props.vocabularyPrimaryLanguage].trim() === ""
-    );
   };
 
   public removeTranslation = (lang: string) => {
@@ -513,7 +506,7 @@ export class TermMetadataEdit extends React.Component<
                     <Button
                       id="edit-term-submit"
                       color="success"
-                      disabled={!isTermValid(this.state, this.state.labelExist)}
+                      disabled={this.isInvalid()}
                       size="sm"
                       onClick={this.onSave}
                     >

--- a/src/component/term/TermMetadataEdit.tsx
+++ b/src/component/term/TermMetadataEdit.tsx
@@ -250,7 +250,7 @@ export class TermMetadataEdit extends React.Component<
   };
 
   public removeTranslation = (lang: string) => {
-    if (lang == this.props.vocabularyPrimaryLanguage) {
+    if (lang === this.props.vocabularyPrimaryLanguage) {
       this.props.publishMessage(
         new Message(
           {

--- a/src/component/term/TermMetadataEdit.tsx
+++ b/src/component/term/TermMetadataEdit.tsx
@@ -66,7 +66,6 @@ interface TermMetadataEditProps extends HasI18n {
   publishMessage: (message: Message) => void;
   selectLanguage: (lang: string) => void;
   validationResults: ConsolidatedResults;
-  vocabulary: Vocabulary;
 }
 
 interface TermMetadataEditState extends TermData {

--- a/src/component/term/TermValidationUtils.ts
+++ b/src/component/term/TermValidationUtils.ts
@@ -27,9 +27,9 @@ export function checkLabelUniqueness(
 
 function labelInEachLanguageValid<T extends TermData>(
   data: T,
-  labelExists: LabelExists
+  labelExists: LabelExists,
+  languages: string[]
 ): boolean {
-  const languages = Object.keys(data.label);
   for (const lang of languages) {
     if (!hasNonBlankValue(data.label, lang) || labelExists[lang]) {
       return false;
@@ -40,12 +40,15 @@ function labelInEachLanguageValid<T extends TermData>(
 
 export function isTermValid<T extends TermData>(
   data: T,
-  labelExists: LabelExists
+  labelExists: LabelExists,
+  vocabularyPrimaryLanguage: string
 ) {
+  const languages = Object.keys(data.label);
   return (
     data.iri !== undefined &&
     data.iri.trim().length > 0 &&
-    labelInEachLanguageValid(data, labelExists)
+    labelInEachLanguageValid(data, labelExists, languages) &&
+    languages.includes(vocabularyPrimaryLanguage)
   );
 }
 export type LabelExists = { [language: string]: boolean };

--- a/src/component/term/__tests__/TermMetadataEdit.test.tsx
+++ b/src/component/term/__tests__/TermMetadataEdit.test.tsx
@@ -94,6 +94,8 @@ describe("Term edit", () => {
         {...intlFunctions()}
       />
     );
+    // mock answer to duplicated label check: 404 meaning label does not exist and so is unique
+    Ajax.head = jest.fn().mockRejectedValue({ status: 404 });
     const newLabel = "New label";
     wrapper
       .find(CustomInput)

--- a/src/component/term/__tests__/TermMetadataEdit.test.tsx
+++ b/src/component/term/__tests__/TermMetadataEdit.test.tsx
@@ -60,6 +60,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -87,6 +89,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -119,6 +123,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -149,6 +155,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -176,6 +184,8 @@ describe("Term edit", () => {
         language="en"
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -204,6 +214,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -228,6 +240,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -259,6 +273,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -280,6 +296,8 @@ describe("Term edit", () => {
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -303,6 +321,8 @@ describe("Term edit", () => {
         language={"en"}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -326,6 +346,8 @@ describe("Term edit", () => {
         language={"cs"}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -343,6 +365,8 @@ describe("Term edit", () => {
         language={"cs"}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -361,6 +385,8 @@ describe("Term edit", () => {
         language={"de"}
         selectLanguage={selectLanguage}
         validationResults={validationResults}
+        publishMessage={jest.fn()}
+        vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
         {...intlFunctions()}
       />
     );
@@ -382,6 +408,8 @@ describe("Term edit", () => {
           language="en"
           selectLanguage={selectLanguage}
           validationResults={validationResults}
+          publishMessage={jest.fn()}
+          vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
           {...intlFunctions()}
         />
       );
@@ -403,6 +431,8 @@ describe("Term edit", () => {
           language="en"
           selectLanguage={selectLanguage}
           validationResults={validationResults}
+          publishMessage={jest.fn()}
+          vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
           {...intlFunctions()}
         />
       );
@@ -423,6 +453,8 @@ describe("Term edit", () => {
           language="en"
           selectLanguage={selectLanguage}
           validationResults={validationResults}
+          publishMessage={jest.fn()}
+          vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
           {...intlFunctions()}
         />
       );
@@ -449,6 +481,8 @@ describe("Term edit", () => {
           language="en"
           selectLanguage={selectLanguage}
           validationResults={validationResults}
+          publishMessage={jest.fn()}
+          vocabularyPrimaryLanguage={Constants.DEFAULT_LANGUAGE}
           {...intlFunctions()}
         />
       );

--- a/src/component/term/__tests__/TermValidationUtils.test.tsx
+++ b/src/component/term/__tests__/TermValidationUtils.test.tsx
@@ -32,10 +32,14 @@ describe("TermValidationUtils", () => {
   });
 
   it("isTermValid returns true if all labels in languages are unique", () => {
-    const valid = isTermValid(term, {
-      cs: false,
-      en: false,
-    });
+    const valid = isTermValid(
+      term,
+      {
+        cs: false,
+        en: false,
+      },
+      Constants.DEFAULT_LANGUAGE
+    );
     expect(valid).toBeTruthy();
   });
 });

--- a/src/component/vocabulary/CreateVocabularyForm.tsx
+++ b/src/component/vocabulary/CreateVocabularyForm.tsx
@@ -66,7 +66,7 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
   const [fileContents, setFileContents] = useState<File[]>([]);
   const [documentLabel, setDocumentLabel] = useState("");
   const [shouldGenerateIri, setShouldGenerateIri] = useState(true);
-  const [primaryLanguage, setPrimaryLanguage] = useState<string | undefined>();
+  const [primaryLanguage, setPrimaryLanguage] = useState<string>(language);
 
   const onIriChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.currentTarget.value.trim().length === 0) {
@@ -139,6 +139,13 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
     setComment(data.comment);
   };
 
+  const removeTranslationIfEmpty = (lang: string) => {
+    if (label[lang] || comment[lang]) {
+      return;
+    }
+    removeTranslation(lang);
+  };
+
   const onPrimaryLanguageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newPrimaryLanguage = e.currentTarget.value;
     // set the change in state
@@ -147,6 +154,7 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
     // if no, create and switch to it
     console.debug(newPrimaryLanguage);
     if (label[newPrimaryLanguage] == null) {
+      removeTranslationIfEmpty(language);
       selectLanguage(newPrimaryLanguage);
       window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
     }

--- a/src/component/vocabulary/CreateVocabularyForm.tsx
+++ b/src/component/vocabulary/CreateVocabularyForm.tsx
@@ -162,7 +162,7 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
     lang: string,
     currentPrimaryLanguage: string = primaryLanguage
   ) => {
-    if (lang == currentPrimaryLanguage) {
+    if (lang === currentPrimaryLanguage) {
       dispatch(
         publishMessage(
           new Message(

--- a/src/component/vocabulary/CreateVocabularyForm.tsx
+++ b/src/component/vocabulary/CreateVocabularyForm.tsx
@@ -21,6 +21,8 @@ import VocabularyUtils from "../../util/VocabularyUtils";
 import Document from "../../model/Document";
 import EditLanguageSelector from "../multilingual/EditLanguageSelector";
 import _ from "lodash";
+import Select from "../misc/Select";
+import { getLanguageOptions } from "../../util/IntlUtil";
 
 interface CreateVocabularyFormProps {
   onSave: (
@@ -64,6 +66,7 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
   const [fileContents, setFileContents] = useState<File[]>([]);
   const [documentLabel, setDocumentLabel] = useState("");
   const [shouldGenerateIri, setShouldGenerateIri] = useState(true);
+  const [primaryLanguage, setPrimaryLanguage] = useState<string | undefined>();
 
   const onIriChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.currentTarget.value.trim().length === 0) {
@@ -112,6 +115,7 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
       iri,
       label,
       comment,
+      primaryLanguage,
     });
     vocabulary.addType(VocabularyUtils.DOCUMENT_VOCABULARY);
     const document = new Document({
@@ -133,6 +137,19 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
     Vocabulary.removeTranslation(data, lang);
     setLabel(data.label);
     setComment(data.comment);
+  };
+
+  const onPrimaryLanguageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newPrimaryLanguage = e.currentTarget.value;
+    // set the change in state
+    setPrimaryLanguage(newPrimaryLanguage);
+    // check if this vocabulary has attributes in that language
+    // if no, create and switch to it
+    console.debug(newPrimaryLanguage);
+    if (label[newPrimaryLanguage] == null) {
+      selectLanguage(newPrimaryLanguage);
+      window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+    }
   };
 
   return (
@@ -192,6 +209,28 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
                     value={documentLabel}
                     onChange={(e) => setDocumentLabel(e.currentTarget.value)}
                   />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <Select
+                    key="edit-vocabulary-language-selector"
+                    label={i18n("vocabulary.primaryLanguage")}
+                    value={primaryLanguage}
+                    onChange={onPrimaryLanguageChange}
+                    hint={i18n("required")}
+                  >
+                    {getLanguageOptions().map((l) => (
+                      <option
+                        key={
+                          "edit-vocabulary-language-selector-option" + l.code
+                        }
+                        value={l.code}
+                      >
+                        {l.name}
+                      </option>
+                    ))}
+                  </Select>
                 </Col>
               </Row>
               <Files

--- a/src/component/vocabulary/CreateVocabularyForm.tsx
+++ b/src/component/vocabulary/CreateVocabularyForm.tsx
@@ -227,7 +227,7 @@ const CreateVocabularyForm: React.FC<CreateVocabularyFormProps> = ({
                         }
                         value={l.code}
                       >
-                        {l.name}
+                        {l.nativeName}
                       </option>
                     ))}
                   </Select>

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -27,7 +27,6 @@ import EditLanguageSelector from "../multilingual/EditLanguageSelector";
 import _ from "lodash";
 import { isValid } from "./VocabularyValidationUtils";
 import { getLanguageOptions } from "../../util/IntlUtil";
-import { Configuration } from "../../model/Configuration";
 import Select from "../misc/Select";
 import Message from "../../model/Message";
 import MessageType from "../../model/MessageType";
@@ -42,7 +41,6 @@ interface VocabularyEditProps extends HasI18n {
   saveDocument: (document: Document) => void;
   language: string;
   selectLanguage: (lang: string) => void;
-  configuration: Configuration;
   publishMessage: (message: Message) => void;
 }
 

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -221,6 +221,28 @@ export class VocabularyEdit extends React.Component<
                   />
                 </Col>
               </Row>
+              <Row>
+                <Col xs={12}>
+                  <Select
+                    key="edit-vocabulary-language-selector"
+                    label={i18n("vocabulary.primaryLanguage")}
+                    value={this.state.primaryLanguage}
+                    onChange={this.onPrimaryLanguageChange}
+                    hint={i18n("required")}
+                  >
+                    {getLanguageOptions().map((l) => (
+                      <option
+                        key={
+                          "edit-vocabulary-language-selector-option" + l.code
+                        }
+                        value={l.code}
+                      >
+                        {l.nativeName}
+                      </option>
+                    ))}
+                  </Select>
+                </Col>
+              </Row>
               <ImportedVocabulariesListEdit
                 vocabulary={this.props.vocabulary}
                 importedVocabularies={this.state.importedVocabularies}
@@ -248,28 +270,6 @@ export class VocabularyEdit extends React.Component<
                     }
                     hint={i18n("required")}
                   />
-                </Col>
-              </Row>
-              <Row>
-                <Col xs={12}>
-                  <Select
-                    key="edit-vocabulary-language-selector"
-                    label={i18n("vocabulary.primaryLanguage")}
-                    value={this.state.primaryLanguage}
-                    onChange={this.onPrimaryLanguageChange}
-                    hint={i18n("required")}
-                  >
-                    {getLanguageOptions().map((l) => (
-                      <option
-                        key={
-                          "edit-vocabulary-language-selector-option" + l.code
-                        }
-                        value={l.code}
-                      >
-                        {l.nativeName}
-                      </option>
-                    ))}
-                  </Select>
                 </Col>
               </Row>
               <Row>

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -100,7 +100,7 @@ export class VocabularyEdit extends React.Component<
     lang: string,
     currentPrimaryLanguage: string = this.state.primaryLanguage
   ) => {
-    if (lang == currentPrimaryLanguage) {
+    if (lang === currentPrimaryLanguage) {
       this.props.publishMessage(
         new Message(
           {

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -74,7 +74,6 @@ export class VocabularyEdit extends React.Component<
       primaryLanguage: props.vocabulary.primaryLanguage || this.props.language,
       unmappedProperties: this.props.vocabulary.unmappedProperties,
     };
-    console.debug(props.vocabulary);
   }
 
   public onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -25,7 +25,6 @@ import MultilingualString, {
 } from "../../model/MultilingualString";
 import EditLanguageSelector from "../multilingual/EditLanguageSelector";
 import _ from "lodash";
-import { isValid } from "./VocabularyValidationUtils";
 import { getLanguageOptions } from "../../util/IntlUtil";
 import Select from "../misc/Select";
 import Message from "../../model/Message";
@@ -33,6 +32,7 @@ import MessageType from "../../model/MessageType";
 import { ThunkDispatch } from "../../util/Types";
 import { connect } from "react-redux";
 import { publishMessage as publishMessageAction } from "../../action/SyncActions";
+import { isVocabularyValid } from "./VocabularyValidationUtils";
 
 interface VocabularyEditProps extends HasI18n {
   vocabulary: Vocabulary;
@@ -135,23 +135,15 @@ export class VocabularyEdit extends React.Component<
     }
   };
 
-  private isPrimaryLabelMissing = () => {
+  private isInvalid() {
     return (
-      this.state.label[this.state.primaryLanguage] == null ||
-      this.state.label[this.state.primaryLanguage].trim() === ""
+      !isVocabularyValid(this.state) ||
+      this.state.documentLabel?.trim().length === 0
     );
-  };
+  }
 
   public onSave = () => {
-    if (this.isPrimaryLabelMissing()) {
-      this.props.publishMessage(
-        new Message(
-          {
-            messageId: "vocabulary.modify.error.missingPrimaryLabel",
-          },
-          MessageType.ERROR
-        )
-      );
+    if (this.isInvalid()) {
       return;
     }
 
@@ -288,10 +280,7 @@ export class VocabularyEdit extends React.Component<
                       onClick={this.onSave}
                       color="success"
                       size="sm"
-                      disabled={
-                        !isValid(this.state.label) ||
-                        this.state.documentLabel?.trim().length === 0
-                      }
+                      disabled={this.isInvalid()}
                     >
                       {i18n("save")}
                     </Button>

--- a/src/component/vocabulary/VocabularyEdit.tsx
+++ b/src/component/vocabulary/VocabularyEdit.tsx
@@ -236,7 +236,7 @@ export class VocabularyEdit extends React.Component<
                         }
                         value={l.code}
                       >
-                        {l.name}
+                        {l.nativeName}
                       </option>
                     ))}
                   </Select>

--- a/src/component/vocabulary/VocabularySummary.tsx
+++ b/src/component/vocabulary/VocabularySummary.tsx
@@ -320,6 +320,7 @@ export class VocabularySummary extends EditableComponent<
               vocabulary={vocabulary}
               language={this.state.language}
               selectLanguage={this.setLanguage}
+              configuration={this.props.configuration}
             />
           ) : (
             <VocabularyMetadata

--- a/src/component/vocabulary/VocabularySummary.tsx
+++ b/src/component/vocabulary/VocabularySummary.tsx
@@ -320,7 +320,6 @@ export class VocabularySummary extends EditableComponent<
               vocabulary={vocabulary}
               language={this.state.language}
               selectLanguage={this.setLanguage}
-              configuration={this.props.configuration}
             />
           ) : (
             <VocabularyMetadata

--- a/src/component/vocabulary/VocabularySummary.tsx
+++ b/src/component/vocabulary/VocabularySummary.tsx
@@ -94,7 +94,8 @@ export function resolveInitialLanguage(
 ) {
   const supported = vocabulary ? Vocabulary.getLanguages(vocabulary) : [];
   const langLocale = getShortLocale(locale);
-  return supported.indexOf(langLocale) !== -1 ? langLocale : configuredLanguage;
+  const fallbackLanguage = vocabulary?.primaryLanguage || configuredLanguage;
+  return supported.indexOf(langLocale) !== -1 ? langLocale : fallbackLanguage;
 }
 
 export class VocabularySummary extends EditableComponent<

--- a/src/component/vocabulary/VocabularyValidationUtils.ts
+++ b/src/component/vocabulary/VocabularyValidationUtils.ts
@@ -2,7 +2,18 @@ import {
   hasNonBlankValue,
   MultilingualString,
 } from "../../model/MultilingualString";
+import { VocabularyData } from "../../model/Vocabulary";
 
-export function isValid(label: MultilingualString): boolean {
+function isLabelInEachLanguageNotBlank(label: MultilingualString): boolean {
   return Object.keys(label).every((lang) => hasNonBlankValue(label, lang));
+}
+
+export function isVocabularyValid<T extends VocabularyData>(
+  vocabularyData: T
+): boolean {
+  return (
+    isLabelInEachLanguageNotBlank(vocabularyData.label) &&
+    !!vocabularyData.primaryLanguage &&
+    hasNonBlankValue(vocabularyData.label, vocabularyData.primaryLanguage)
+  );
 }

--- a/src/component/vocabulary/__tests__/CreateVocabulary.test.tsx
+++ b/src/component/vocabulary/__tests__/CreateVocabulary.test.tsx
@@ -160,6 +160,7 @@ describe("Create vocabulary view", () => {
         comment: langString(comment),
         document,
         types,
+        primaryLanguage: Constants.DEFAULT_LANGUAGE,
       })
     );
   });

--- a/src/component/vocabulary/__tests__/VocabularyEdit.test.tsx
+++ b/src/component/vocabulary/__tests__/VocabularyEdit.test.tsx
@@ -23,6 +23,7 @@ describe("VocabularyEdit", () => {
     onDocumentSave = jest.fn();
     onCancel = jest.fn();
     vocabulary = new Vocabulary({
+      primaryLanguage: Constants.DEFAULT_LANGUAGE,
       iri: Generator.generateUri(),
       label: langString("Test vocabulary"),
     });
@@ -37,11 +38,14 @@ describe("VocabularyEdit", () => {
         cancel={onCancel}
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={jest.fn()}
+        publishMessage={jest.fn()}
         {...intlFunctions()}
       />
     );
-    const newName = "Metropolitan plan";
-    const newDescription = "Vocabulary description text";
+    const newName = wrapper.instance().state.label;
+    newName[Constants.DEFAULT_LANGUAGE] = "Metropolitan plan";
+    const newDescription = wrapper.instance().state.label;
+    newDescription[Constants.DEFAULT_LANGUAGE] = "Vocabulary description text";
     wrapper.instance().onChange({ label: newName });
     wrapper.instance().onChange({ comment: newDescription });
     wrapper.instance().onSave();
@@ -61,6 +65,7 @@ describe("VocabularyEdit", () => {
         cancel={onCancel}
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={jest.fn()}
+        publishMessage={jest.fn()}
         {...intlFunctions()}
       />
     );
@@ -79,6 +84,7 @@ describe("VocabularyEdit", () => {
         cancel={onCancel}
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={jest.fn()}
+        publishMessage={jest.fn()}
         {...intlFunctions()}
       />
     );
@@ -100,6 +106,7 @@ describe("VocabularyEdit", () => {
         cancel={onCancel}
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={jest.fn()}
+        publishMessage={jest.fn()}
         {...intlFunctions()}
       />
     );
@@ -122,6 +129,7 @@ describe("VocabularyEdit", () => {
         cancel={onCancel}
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={jest.fn()}
+        publishMessage={jest.fn()}
         {...intlFunctions()}
       />
     );
@@ -150,6 +158,7 @@ describe("VocabularyEdit", () => {
         cancel={onCancel}
         language={Constants.DEFAULT_LANGUAGE}
         selectLanguage={jest.fn()}
+        publishMessage={jest.fn()}
         {...intlFunctions()}
       />
     );

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -286,8 +286,6 @@ const cs = {
     "vocabulary.create.files": "Soubory",
     "vocabulary.create.files.help":
       "Nepovinné. Můžete připojit soubory (např. texty zákonů), ze kterých bude slovník vycházet.",
-    "vocabulary.modify.error.missingPrimaryLabel":
-      "Slovníku chybí název v jeho hlavním jazyku!",
     "vocabulary.comment": "Popis",
     "vocabulary.summary.title": "{name} - přehled",
     "vocabulary.summary.gotodetail.label": "Zobrazit pojmy v tomto slovníku",

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -262,6 +262,8 @@ const cs = {
     "asset.remove.dialog.title": 'Odstranit {type} "{label}"?',
     "asset.modify.dialog.title": 'Upravit {type} "{label}"',
     "asset.remove.dialog.text": 'Určitě chcete odstranit {type} "{label}"?',
+    "asset.modify.error.cannotRemoveVocabularyPrimaryLanguage":
+      "Nelze odebrat překlad pro hlavní jazyk slovníku!",
 
     "document.remove.tooltip.disabled":
       "Odstranit dokument je možné po odstranění všech jeho souborů.",
@@ -284,6 +286,8 @@ const cs = {
     "vocabulary.create.files": "Soubory",
     "vocabulary.create.files.help":
       "Nepovinné. Můžete připojit soubory (např. texty zákonů), ze kterých bude slovník vycházet.",
+    "vocabulary.modify.error.missingPrimaryLabel":
+      "Slovníku chybí název v jeho hlavním jazyku!",
     "vocabulary.comment": "Popis",
     "vocabulary.summary.title": "{name} - přehled",
     "vocabulary.summary.gotodetail.label": "Zobrazit pojmy v tomto slovníku",

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -278,6 +278,7 @@ const cs = {
     "vocabulary.vocabularies.select.placeholder":
       "Začněte psát pro filtrování slovníků dle názvu",
     "vocabulary.title": "Název",
+    "vocabulary.primaryLanguage": "Hlavní jazyk slovníku",
     "vocabulary.create.title": "Nový slovník",
     "vocabulary.create.submit": "Vytvořit",
     "vocabulary.create.files": "Soubory",

--- a/src/i18n/cs.ts
+++ b/src/i18n/cs.ts
@@ -628,6 +628,7 @@ const cs = {
 
     "file.text-analysis.finished.message":
       "Textová analýza souboru úspěšně dokončena.",
+    "file.text-analysis.failed": "Textová analýza selhala: {message}",
     "file.metadata.startTextAnalysis": "Spustit textovou analýzu",
     "file.metadata.startTextAnalysis.text": "Analyzovat",
     "file.metadata.startTextAnalysis.vocabularySelect.title":

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -252,6 +252,8 @@ const en = {
     "asset.modify.dialog.title": 'Modify {type} "{label}"',
     "asset.remove.dialog.text":
       'Are you sure you want to remove {type} "{label}"?',
+    "asset.modify.error.cannotRemoveVocabularyPrimaryLanguage":
+      "Cannot remove translation in the vocabulary primary language!",
 
     "document.remove.tooltip.disabled":
       "In order to delete the document, delete the files first.",
@@ -275,6 +277,8 @@ const en = {
     "vocabulary.create.files": "Files",
     "vocabulary.create.files.help":
       "Optional. You can upload files (e.g. a texts of law) here.",
+    "vocabulary.modify.error.missingPrimaryLabel":
+      "The vocabulary is missing label in its primary language.",
     "vocabulary.comment": "Description",
     "vocabulary.summary.title": "{name} - Summary",
     "vocabulary.summary.gotodetail.label": "View terms in this vocabulary",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -269,6 +269,7 @@ const en = {
     "vocabulary.vocabularies.select.placeholder":
       "Start typing to filter vocabularies by name",
     "vocabulary.title": "Title",
+    "vocabulary.primaryLanguage": "Primary vocabulary language",
     "vocabulary.create.title": "Create Vocabulary",
     "vocabulary.create.submit": "Create",
     "vocabulary.create.files": "Files",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -277,8 +277,6 @@ const en = {
     "vocabulary.create.files": "Files",
     "vocabulary.create.files.help":
       "Optional. You can upload files (e.g. a texts of law) here.",
-    "vocabulary.modify.error.missingPrimaryLabel":
-      "The vocabulary is missing label in its primary language.",
     "vocabulary.comment": "Description",
     "vocabulary.summary.title": "{name} - Summary",
     "vocabulary.summary.gotodetail.label": "View terms in this vocabulary",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -619,6 +619,7 @@ const en = {
 
     "file.text-analysis.finished.message":
       "Text analysis successfully finished.",
+    "file.text-analysis.failed": "Text analysis failed: {message}",
     "file.metadata.startTextAnalysis": "Start text analysis",
     "file.metadata.startTextAnalysis.text": "Analyze",
     "file.metadata.startTextAnalysis.vocabularySelect.title":

--- a/src/model/Message.ts
+++ b/src/model/Message.ts
@@ -55,9 +55,16 @@ export function createStringMessage(text: string) {
   return new Message({ message: text });
 }
 
-export function createFormattedMessage(mId: string, values?: {}) {
-  return new Message({
-    messageId: mId,
-    values,
-  });
+export function createFormattedMessage(
+  mId: string,
+  values?: {},
+  type: MessageType = MType.INFO
+) {
+  return new Message(
+    {
+      messageId: mId,
+      values,
+    },
+    type
+  );
 }

--- a/src/model/MultilingualString.ts
+++ b/src/model/MultilingualString.ts
@@ -146,7 +146,7 @@ export function hasNonBlankValue(
   str?: MultilingualString,
   lang: string = Constants.DEFAULT_LANGUAGE
 ) {
-  return str && (str[getShortLocale(lang)] || "").trim().length > 0;
+  return !!str && (str[getShortLocale(lang)] || "").trim().length > 0;
 }
 
 export default MultilingualString;

--- a/src/model/Vocabulary.ts
+++ b/src/model/Vocabulary.ts
@@ -11,7 +11,11 @@ import Constants from "../util/Constants";
 import { SupportsSnapshots } from "./Snapshot";
 import JsonLdUtils from "../util/JsonLdUtils";
 import AccessLevel, { strToAccessLevel } from "./acl/AccessLevel";
-import { getLanguages, removeTranslation } from "../util/IntlUtil";
+import {
+  getLanguageByShortCode,
+  getLanguages,
+  removeTranslation,
+} from "../util/IntlUtil";
 import {
   context,
   getLocalized,
@@ -31,6 +35,7 @@ const ctx = {
   model: VocabularyUtils.HAS_MODEL,
   importedVocabularies: VocabularyUtils.IMPORTS_VOCABULARY,
   accessLevel: JsonLdUtils.idContext(VocabularyUtils.HAS_ACCESS_LEVEL),
+  primaryLanguage: VocabularyUtils.DC_LANGUAGE,
 };
 
 export const CONTEXT = Object.assign({}, ASSET_CONTEXT, ctx);
@@ -48,6 +53,7 @@ const MAPPED_PROPERTIES = [
   "allImportedVocabularies",
   "termCount",
   "accessLevel",
+  "primaryLanguage",
 ];
 
 export const VOCABULARY_MULTILINGUAL_ATTRIBUTES = ["label", "comment"];
@@ -60,6 +66,11 @@ export interface VocabularyData extends AssetData {
   model?: AssetData;
   importedVocabularies?: AssetData[];
   accessLevel?: AccessLevel;
+  /**
+   * Short locale code defined by iso-639-1
+   * @see import("../util/IntlUtil").getLanguageOptions()
+   */
+  primaryLanguage?: string;
 }
 
 export default class Vocabulary
@@ -74,6 +85,7 @@ export default class Vocabulary
   public importedVocabularies?: AssetData[];
   public allImportedVocabularies?: string[];
   public accessLevel?: AccessLevel;
+  public primaryLanguage?: string;
 
   public termCount?: number;
 
@@ -91,6 +103,7 @@ export default class Vocabulary
     this.accessLevel = data.accessLevel
       ? strToAccessLevel(data.accessLevel)
       : undefined;
+    this.primaryLanguage = data.primaryLanguage;
   }
 
   getLabel(lang?: string): string {
@@ -161,4 +174,5 @@ export default class Vocabulary
 export const EMPTY_VOCABULARY = new Vocabulary({
   iri: Constants.EMPTY_ASSET_IRI,
   label: langString(""),
+  primaryLanguage: getLanguageByShortCode(Constants.DEFAULT_LANGUAGE)?.code,
 });

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -134,6 +134,7 @@ const constants = {
     VOCABULARIES_TEXT_ANALYSIS_FINISHED_FILE:
       "/vocabularies/text_analysis/finished/file",
     LONG_RUNNING_TASKS_UPDATE: "/long-running-tasks/update",
+    VOCABULARIES_TEXT_ANALYSIS_FAILED: "/vocabularies/text_analysis/failed",
   },
   // Number of milliseconds after which a websocket request should be retried
   WEBSOCKET_REQUEST_TIMEOUT: 60 * 1000 /* 1 minute */,

--- a/src/util/IntlUtil.ts
+++ b/src/util/IntlUtil.ts
@@ -124,3 +124,13 @@ const LANGUAGE_OPTIONS = prioritizeLanguages(
 export function getLanguageOptions(): Language[] {
   return LANGUAGE_OPTIONS;
 }
+
+/**
+ * Gets a language matching its code.
+ *
+ * The languages are retrieved using the iso-639-1 JS library.
+ * @param code The short code to match e.g.: "cs"
+ */
+export function getLanguageByShortCode(code: string): Language | undefined {
+  return LANGUAGE_OPTIONS.find((lang) => lang.code === code);
+}


### PR DESCRIPTION
Resolves #521

- Adds primary language selector to vocabulary edit and creation form
- Vocabulary language is now also pre-selected when creating a new term
- Vocabulary and Terms are prevented from saving when label translation in the vocabulary primary language is missing
- WebSocket is now also monitored for notifications from text analysis failure