### PR TITLE
[Fix] Fix Term definition source link using document instead of vocabulary causing invalid linking to annotator

### DIFF
--- a/src/component/term/TermDefinitionSourceLink.tsx
+++ b/src/component/term/TermDefinitionSourceLink.tsx
@@ -45,7 +45,9 @@ export const TermDefinitionSourceLink: React.FC<
         selector,
       })
     );
-    const ownerIri = VocabularyUtils.create(file.owner.iri!);
+    const ownerIri = VocabularyUtils.create(
+      file.owner.vocabulary?.iri || file.owner.iri
+    );
     Routing.transitionTo(Routes.annotateFile, {
       params: new Map([
         ["name", ownerIri.fragment],


### PR DESCRIPTION
Button in term detail for navigation to term definition source was redirecting to annotator using a document IRI, resulting in an invalid URL `/vocabularies/document/document/<file>`. The issue is resolved by using the vocabulary IRI if it is available, resulting in a correct URL  `/vocabularies/<vocabulary>/document/<file>`.