### PR TITLE
[Enhancement #659] Restrict full-text search language selection to available languages

### DIFF
--- a/src/action/AsyncActions.ts
+++ b/src/action/AsyncActions.ts
@@ -1365,6 +1365,7 @@ export function loadConfiguration() {
         data.roles = Utils.sanitizeArray(data.roles).map(
           (d: UserRoleData) => new UserRole(d)
         );
+        data.indexedLanguages = Utils.sanitizeArray(data.indexedLanguages);
         return dispatch(asyncActionSuccessWithPayload(action, data));
       })
       .catch((error) => dispatch(asyncActionFailure(action, error)));

--- a/src/component/resource/file/LanguageSelector.tsx
+++ b/src/component/resource/file/LanguageSelector.tsx
@@ -9,8 +9,9 @@ const LanguageSelector: React.FC<{
   value: string;
   className?: string;
   isClearable?: boolean;
-}> = ({ onChange, value, className, isClearable = false }) => {
-  const options = getLanguageOptions();
+  languageOptions?: Language[];
+}> = ({ onChange, value, className, isClearable = false, languageOptions }) => {
+  const options = languageOptions || getLanguageOptions();
   const { i18n } = useI18n();
   return (
     <IntelligentTreeSelect

--- a/src/component/search/label/NavbarSearch.tsx
+++ b/src/component/search/label/NavbarSearch.tsx
@@ -234,7 +234,9 @@ export class NavbarSearch extends React.Component<
             onChange={this.onChange}
             onKeyPress={this.onKeyPress}
           />
-          {languageSelect}
+          {!!this.props.indexedLanguages?.length &&
+            this.props.indexedLanguages.length > 1 &&
+            languageSelect}
           {!navbar && searchIcon}
           {this.props.searchString && clearIcon}
         </InputGroup>

--- a/src/component/search/label/NavbarSearch.tsx
+++ b/src/component/search/label/NavbarSearch.tsx
@@ -23,6 +23,7 @@ import { FaTimes } from "react-icons/fa";
 import "./NavbarSearch.scss";
 import { isLoggedIn } from "../../../util/Authorization";
 import LanguageSelector from "../../resource/file/LanguageSelector";
+import { getLanguageByShortCode, Language } from "../../../util/IntlUtil";
 
 interface NavbarSearchProps extends HasI18n, RouteComponentProps<any> {
   updateSearchFilter: (searchString: string, language: string) => any;
@@ -31,6 +32,7 @@ interface NavbarSearchProps extends HasI18n, RouteComponentProps<any> {
   navbar: boolean;
   closeCollapse?: () => void;
   user: User;
+  indexedLanguages?: Language[];
 }
 
 interface NavbarSearchState {
@@ -51,6 +53,17 @@ const ROUTES_WITHOUT_SEARCH_OVERLAY = [
   Routes.publicSearchTerms,
   Routes.publicSearchVocabularies,
 ];
+
+function mapIndexedLanguages(languages?: string[]): Language[] | undefined {
+  const mapped = languages
+    ?.map(getLanguageByShortCode)
+    ?.filter((l): l is Language => !!l);
+  if (!mapped?.length || mapped?.length === 0) {
+    // treat null, undefined and empty array as undefined
+    return undefined;
+  }
+  return mapped;
+}
 
 export class NavbarSearch extends React.Component<
   NavbarSearchProps,
@@ -175,6 +188,7 @@ export class NavbarSearch extends React.Component<
           onChange={this.onLanguageSelectChange}
           value={this.state.selectedLanguage}
           isClearable={true}
+          languageOptions={this.props.indexedLanguages}
         />
       </InputGroupAddon>
     );
@@ -262,6 +276,9 @@ export default withRouter(
         searchResults: state.searchResults,
         intl: state.intl, // Pass intl in props to force UI re-render on language switch
         user: state.user,
+        indexedLanguages: mapIndexedLanguages(
+          state.configuration.indexedLanguages
+        ),
       };
     },
     (dispatch: ThunkDispatch) => {

--- a/src/component/search/label/NavbarSearch.tsx
+++ b/src/component/search/label/NavbarSearch.tsx
@@ -24,6 +24,7 @@ import "./NavbarSearch.scss";
 import { isLoggedIn } from "../../../util/Authorization";
 import LanguageSelector from "../../resource/file/LanguageSelector";
 import { getLanguageByShortCode, Language } from "../../../util/IntlUtil";
+import Utils from "../../../util/Utils";
 
 interface NavbarSearchProps extends HasI18n, RouteComponentProps<any> {
   updateSearchFilter: (searchString: string, language: string) => any;
@@ -32,7 +33,7 @@ interface NavbarSearchProps extends HasI18n, RouteComponentProps<any> {
   navbar: boolean;
   closeCollapse?: () => void;
   user: User;
-  indexedLanguages?: Language[];
+  indexedLanguages: Language[];
 }
 
 interface NavbarSearchState {
@@ -54,15 +55,10 @@ const ROUTES_WITHOUT_SEARCH_OVERLAY = [
   Routes.publicSearchVocabularies,
 ];
 
-function mapIndexedLanguages(languages?: string[]): Language[] | undefined {
-  const mapped = languages
-    ?.map(getLanguageByShortCode)
-    ?.filter((l): l is Language => !!l);
-  if (!mapped?.length || mapped?.length === 0) {
-    // treat null, undefined and empty array as undefined
-    return undefined;
-  }
-  return mapped;
+function mapIndexedLanguages(languages?: string[]): Language[] {
+  return Utils.sanitizeArray(languages)
+    .map(getLanguageByShortCode)
+    .filter((l): l is Language => !!l);
 }
 
 export class NavbarSearch extends React.Component<
@@ -234,9 +230,7 @@ export class NavbarSearch extends React.Component<
             onChange={this.onChange}
             onKeyPress={this.onKeyPress}
           />
-          {!!this.props.indexedLanguages?.length &&
-            this.props.indexedLanguages.length > 1 &&
-            languageSelect}
+          {this.props.indexedLanguages.length > 1 && languageSelect}
           {!navbar && searchIcon}
           {this.props.searchString && clearIcon}
         </InputGroup>

--- a/src/component/search/label/__tests__/NavbarSearch.test.tsx
+++ b/src/component/search/label/__tests__/NavbarSearch.test.tsx
@@ -189,8 +189,8 @@ describe("NavbarSearch", () => {
     expect(inputGroup.childAt(1).prop("id")).toEqual(
       "main-search-input-navbar"
     );
-    expect(inputGroup.childAt(3).prop("id")).toEqual("search-reset");
-    expect(inputGroup.children().length).toEqual(4);
+    expect(inputGroup.childAt(2).prop("id")).toEqual("search-reset");
+    expect(inputGroup.children().length).toEqual(3);
   });
 
   it("renders icon after input if search is not in navbar", () => {
@@ -207,9 +207,9 @@ describe("NavbarSearch", () => {
     );
     const inputGroup = wrapper.find(InputGroup);
     expect(inputGroup.childAt(0).prop("id")).toEqual("main-search-input");
-    expect(inputGroup.childAt(2).prop("id")).toEqual("search-icon");
-    expect(inputGroup.childAt(3).prop("id")).toEqual("search-reset");
-    expect(inputGroup.children().length).toEqual(4);
+    expect(inputGroup.childAt(1).prop("id")).toEqual("search-icon");
+    expect(inputGroup.childAt(2).prop("id")).toEqual("search-reset");
+    expect(inputGroup.children().length).toEqual(3);
   });
 
   it("does not render clear icon if search string is empty", () => {

--- a/src/component/search/label/__tests__/NavbarSearch.test.tsx
+++ b/src/component/search/label/__tests__/NavbarSearch.test.tsx
@@ -33,7 +33,7 @@ describe("NavbarSearch", () => {
   ];
 
   const navbarConnections = () => {
-    return { updateSearchFilter, ...routingProps() };
+    return { updateSearchFilter, ...routingProps(), indexedLanguages: [] };
   };
 
   beforeEach(() => {

--- a/src/model/Configuration.ts
+++ b/src/model/Configuration.ts
@@ -9,6 +9,7 @@ const ctx = {
   maxFileUploadSize: `${VocabularyUtils.NS_TERMIT}má-maximální-velikost-souboru`,
   versionSeparator: `${VocabularyUtils.NS_TERMIT}má-oddělovač-verze`,
   modelingToolUrl: `${VocabularyUtils.NS_TERMIT}má-adresu-modelovacího-nástroje`,
+  indexedLanguages: `${VocabularyUtils.NS_TERMIT}má-indexovaný-jazyk`,
 };
 
 export const CONTEXT = Object.assign({}, USERROLE_CONTEXT, ctx);
@@ -23,6 +24,7 @@ export interface Configuration {
   maxFileUploadSize: string;
   versionSeparator: string;
   modelingToolUrl?: string;
+  indexedLanguages: string[];
 }
 
 export const DEFAULT_CONFIGURATION: Configuration = {
@@ -31,4 +33,5 @@ export const DEFAULT_CONFIGURATION: Configuration = {
   roles: [],
   maxFileUploadSize: "",
   versionSeparator: "",
+  indexedLanguages: [],
 };


### PR DESCRIPTION
resolves #659
- Loads indexed languages from the configuration endpoint
- Restricts the full-text search language selection to indexed languages
- Allows all language options in a case when no indexed language is found
- Indexed languages are filtered only to valid options according to Intl